### PR TITLE
Unlimit directive stream request's running time

### DIFF
--- a/NuguCore/Sources/Business/Network/HTTP/NuguApiProvider.swift
+++ b/NuguCore/Sources/Business/Network/HTTP/NuguApiProvider.swift
@@ -241,7 +241,7 @@ class NuguApiProvider: NSObject {
                     return disposable
                 }
                 
-                var downstreamRequest = URLRequest(url: downstreamUrl, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 600.0)
+                var downstreamRequest = URLRequest(url: downstreamUrl, cachePolicy: .useProtocolCachePolicy, timeoutInterval: Double.infinity)
                 downstreamRequest.httpMethod = NuguApi.directives.method.rawValue
                 downstreamRequest.allHTTPHeaderFields = NuguApi.directives.header
                 self.directiveTask = self.session.dataTask(with: downstreamRequest)


### PR DESCRIPTION
* Directive request timeout is 10 minutes before.
* So `NetworkManager` have to reconnect every single timeout.
* `Ping` Api is not helpful in this case because it never send the response to directive stream.