### PR TITLE
Limit only one request at once.

### DIFF
--- a/NuguCore/Sources/Business/Capability/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguCore/Sources/Business/Capability/AutomaticSpeechRecognition/ASRAgent.swift
@@ -163,10 +163,7 @@ public extension ASRAgent {
         asrDispatchQueue.async { [weak self] in
             guard let self = self else { return }
             
-            switch self.asrState {
-            case .idle, .expectingSpeech:
-                break
-            case .listening, .recognizing, .busy:
+            guard [.listening, .recognizing, .busy].contains(self.asrState) == false else {
                 log.warning("Not permitted in current state \(self.asrState)")
                 return
             }

--- a/NuguCore/Sources/Business/Capability/Text/TextAgent.swift
+++ b/NuguCore/Sources/Business/Capability/Text/TextAgent.swift
@@ -87,26 +87,20 @@ extension TextAgent {
         textDispatchQueue.async { [weak self] in
             guard let self = self else { return }
             
-            switch self.textAgentState {
-            case .idle:
-                break
-            case .busy:
+            guard self.textAgentState != .busy else {
                 log.warning("Not permitted in current state \(self.textAgentState)")
                 return
             }
             
-        }
-        
-        contextManager.getContexts { [weak self] (contextPayload) in
-            guard let self = self else { return }
-            
-            self.textRequest = TextRequest(
-                contextPayload: contextPayload,
-                text: text,
-                dialogRequestId: TimeUUID().hexString
-            )
-            
-            self.focusManager.requestFocus(channelDelegate: self)
+            self.contextManager.getContexts { (contextPayload) in
+                self.textRequest = TextRequest(
+                    contextPayload: contextPayload,
+                    text: text,
+                    dialogRequestId: TimeUUID().hexString
+                )
+                
+                self.focusManager.requestFocus(channelDelegate: self)
+            }
         }
     }
 }


### PR DESCRIPTION
* Refactor `switch` syntax to `guard` syntax to avoid mistakes
