### PR TITLE
Fix `DisplayAgent` bug where deallocated observer is called unexpectly.

### DIFF
--- a/NuguCore/Sources/Extension/NSObject+Rx.swift
+++ b/NuguCore/Sources/Extension/NSObject+Rx.swift
@@ -13,7 +13,7 @@ import RxSwift
 private var deallocatedSubjectTriggerContext: UInt8 = 0
 private var deallocatedSubjectContext: UInt8 = 0
 
-extension Reactive where Base: Any {
+extension Reactive where Base: AnyObject {
     /**
     Observable sequence of object deallocated events.
     
@@ -35,7 +35,7 @@ extension Reactive where Base: Any {
     }
 }
 
-extension Reactive where Base: Any {
+extension Reactive where Base: AnyObject {
     func synchronized<T>( _ action: () -> T) -> T {
         objc_sync_enter(self.base)
         let result = action()

--- a/NuguInterface/Sources/Capability/AudioPlayer/Display/AudioPlayerDisplayDelegate.swift
+++ b/NuguInterface/Sources/Capability/AudioPlayer/Display/AudioPlayerDisplayDelegate.swift
@@ -25,7 +25,7 @@ public protocol AudioPlayerDisplayDelegate: class {
     /// Tells the delegate that the specified template should be displayed.
     ///
     /// - Parameter template: The player template to display.
-    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> Any?
+    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> AnyObject?
     
     /// Tells the delegate that the specified template should be removed from the screen.
     ///

--- a/NuguInterface/Sources/Capability/Display/DisplayAgentDelegate.swift
+++ b/NuguInterface/Sources/Capability/Display/DisplayAgentDelegate.swift
@@ -25,7 +25,7 @@ public protocol DisplayAgentDelegate: class {
     /// Tells the delegate that the specified template should be displayed.
     ///
     /// - Parameter template: The template to display.
-    func displayAgentDidRender(template: DisplayTemplate) -> Any?
+    func displayAgentDidRender(template: DisplayTemplate) -> AnyObject?
     
     /// Tells the delegate that the specified template should be removed from the screen.
     ///

--- a/SampleApp/Sources/Manager/NuguDisplayPlayerController.swift
+++ b/SampleApp/Sources/Manager/NuguDisplayPlayerController.swift
@@ -41,6 +41,8 @@ final class NuguDisplayPlayerController {
     private var currentState: AudioPlayerState = .idle
     private var nowPlayingInfoCenter: MPNowPlayingInfoCenter?
     
+    private var renderingContext: AnyObject?
+    
     // MARK: Initialize
     
     init(client: NuguClient) {
@@ -66,6 +68,7 @@ final class NuguDisplayPlayerController {
         currentItem = nil
         nowPlayingInfoCenter?.nowPlayingInfo = nil
         nowPlayingInfoCenter = nil
+        renderingContext = nil
     }
 }
 
@@ -252,9 +255,10 @@ private extension NuguDisplayPlayerController {
 // MARK: - DisplayPlayerAgentDelegate
 
 extension NuguDisplayPlayerController: AudioPlayerDisplayDelegate {
-    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> Any? {
+    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> AnyObject? {
+        renderingContext = NSObject()
         update(newItem: template)
-        return currentItem
+        return renderingContext
     }
     
     func audioPlayerDisplayShouldClear(template: AudioPlayerDisplayTemplate, reason: AudioPlayerDisplayTemplate.ClearReason) {

--- a/SampleApp/Sources/UI/MainViewController.swift
+++ b/SampleApp/Sources/UI/MainViewController.swift
@@ -571,7 +571,7 @@ extension MainViewController: TextAgentDelegate {
 // MARK: - DisplayAgentDelegate
 
 extension MainViewController: DisplayAgentDelegate {
-    func displayAgentDidRender(template: DisplayTemplate) -> Any? {
+    func displayAgentDidRender(template: DisplayTemplate) -> AnyObject? {
         return addDisplayView(displayTemplate: template)
     }
     
@@ -588,7 +588,7 @@ extension MainViewController: DisplayAgentDelegate {
 // MARK: - DisplayPlayerAgentDelegate
 
 extension MainViewController: AudioPlayerDisplayDelegate {
-    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> Any? {
+    func audioPlayerDisplayDidRender(template: AudioPlayerDisplayTemplate) -> AnyObject? {
         return addDisplayAudioPlayerView(audioPlayerDisplayTemplate: template)
     }
     


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [x] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [x] NUGU Developers
- [x] Github Wiki
-  [NUGU SDK for iOS](https://github.com/nugu-developers/nugu-ios/wiki/How-to-use-NUGU-SDK-for-iOS): 머지후 수정하겠습니다.
## Summary
