### PR TITLE
Modify comparison logic for resuming `AudioPlayerAgent`'s media player.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
@@ -439,7 +439,9 @@ private extension AudioPlayerAgent {
                         }
                         
                         switch self.currentMedia {
-                        case .some(let media) where media.payload.audioItem.stream.token == payload.audioItem.stream.token:
+                        case .some(let media) where
+                            media.payload.audioItem.stream.token == payload.audioItem.stream.token
+                                && media.payload.playServiceId == payload.playServiceId:
                             // Resume and seek
                             self.currentMedia = AudioPlayerAgentMedia(
                                 dialogRequestId: directive.header.dialogRequestId,


### PR DESCRIPTION
* Add playServiceId comparison to decide whether to resume or not.

## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
