### PR TITLE
Fixes a bug where `DisplayAgent.handleControlScroll` doesn't call completion handler.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
@@ -287,6 +287,8 @@ private extension DisplayAgent {
     
     func handleControlScroll() -> HandleDirective {
         return { [weak self] directive, completion in
+            defer { completion() }
+            
             guard let payload = try? JSONDecoder().decode(DisplayControlPayload.self, from: directive.payload) else {
                 log.error("Invalid payload")
                 return


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
