### PR TITLE
Remove `System.SynchronizedState` event that is called when initializing `NuguClient`.

### DIFF
--- a/NuguClientKit/Sources/Client/NuguClient.swift
+++ b/NuguClientKit/Sources/Client/NuguClient.swift
@@ -138,8 +138,6 @@ public class NuguClient {
         setupAudioSessionRequester()
         setupDialogStateAggregator()
         setupStreamDataRouter()
-        
-        systemAgent.sendSynchronizeStateEvent()
     }
 }
     


### PR DESCRIPTION
…

## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
