### PR TITLE
Avoid focus adjustment when the current foreground delegate and requesting delegate are the same

### DIFF
--- a/NuguCore/Sources/Focus/FocusManager.swift
+++ b/NuguCore/Sources/Focus/FocusManager.swift
@@ -61,9 +61,10 @@ extension FocusManager {
                 return
             }
             
-            // 현재 foreground channel 이 우선수위가 낮으면 background 로 변경
+            guard self.foregroundChannelDelegate !== channelDelegate else { return }
+            
+            // Move current foreground channel to background If Its priority is lower than requested.
             if let foregroundChannelDelegate = self.foregroundChannelDelegate,
-                foregroundChannelDelegate !== channelDelegate,
                 channelDelegate.focusChannelPriority().rawValue >= foregroundChannelDelegate.focusChannelPriority().rawValue {
                 self.update(channelDelegate: foregroundChannelDelegate, focusState: .background)
             }


### PR DESCRIPTION
…sting delegate are the same.

## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
