### PR TITLE
Stop the `ASRAgent` when the `EndPointDetector`'s state changes to idle.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -305,13 +305,13 @@ extension ASRAgent: EndPointDetectorDelegate {
             case .listening, .recognizing:
                 break
             case .idle, .expectingSpeech, .busy:
-                log.warning("Not permitted in current state \(self.asrState)")
+                log.info("Not permitted in current state \(self.asrState)")
                 return
             }
             
             switch state {
             case .idle:
-                break
+                self.asrResult = .error(ASRError.listenFailed)
             case .listening:
                 break
             case .start:


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
