### PR TITLE
Assign a higher background channel to the foreground with some delay.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/Sound/SoundMedia.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Sound/SoundMedia.swift
@@ -23,13 +23,11 @@ import Foundation
 import NuguCore
 
 struct SoundMedia {
-    let player: MediaPlayable
     let payload: Payload
     let dialogRequestId: String
     let messageId: String
     
-    init(player: MediaPlayable, payload: Payload, dialogRequestId: String, messageId: String) {
-        self.player = player
+    init(payload: Payload, dialogRequestId: String, messageId: String) {
         self.payload = payload
         self.dialogRequestId = dialogRequestId
         self.messageId = messageId

--- a/NuguCore/Sources/Focus/FocusChannelPriority.swift
+++ b/NuguCore/Sources/Focus/FocusChannelPriority.swift
@@ -47,6 +47,8 @@ public struct FocusChannelPriority {
     public static let media = FocusChannelPriority(requestPriority: 200, maintainPriority: 100)
     /// A priority of `beep` channel.
     public static let beep = FocusChannelPriority(requestPriority: 100, maintainPriority: 150)
+    /// A priority of `sound` channel.
+    public static let sound = FocusChannelPriority(requestPriority: 100, maintainPriority: 100)
     /// A priority of `background` channel.
     public static let background = FocusChannelPriority(requestPriority: 0, maintainPriority: 0)
 }

--- a/NuguCore/Sources/Focus/FocusConst.swift
+++ b/NuguCore/Sources/Focus/FocusConst.swift
@@ -21,5 +21,6 @@
 import Foundation
 
 enum FocusConst {
+    static let shortLatency: DispatchTimeInterval = .milliseconds(30)
     static let releaseLatency: DispatchTimeInterval = .milliseconds(200)
 }


### PR DESCRIPTION
* Modify `SoundAgent`'s focus priority.
* Check the higher background channel before assigning focus.

## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
