### PR TITLE
Fix crash in `MicInputProvider.stop()`.

### DIFF
--- a/NuguCore/Sources/Audio/AudioInput/MicInputProvider.swift
+++ b/NuguCore/Sources/Audio/AudioInput/MicInputProvider.swift
@@ -62,8 +62,12 @@ public class MicInputProvider {
     public func stop() {
         log.debug("try to stop")
         
-        audioEngine.inputNode.removeTap(onBus: audioBus)
-        audioEngine.stop()
+        if let error = ObjcExceptionCatcher.objcTry({
+            audioEngine.inputNode.removeTap(onBus: audioBus)
+            audioEngine.stop()
+        }) {
+            log.error("stop error: \(error)\n")
+        }
     }
     
     private func beginTappingMicrophone(tapBlock: @escaping AVAudioNodeTapBlock) throws {


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
