### PR TITLE
Fixes a bug where `startWakeUpDetector` does not called.

### DIFF
--- a/SampleApp/Sources/Manager/NuguCentralManager.swift
+++ b/SampleApp/Sources/Manager/NuguCentralManager.swift
@@ -91,15 +91,16 @@ extension NuguCentralManager {
         if UserDefaults.Standard.useWakeUpDetector,
             let keyword = Keyword(rawValue: UserDefaults.Standard.wakeUpWord) {
             client.keywordDetector.keywordSource = keyword.keywordSource
+            startWakeUpDetector()
+            
             startMicWorkItem?.cancel()
             startMicWorkItem = DispatchWorkItem(block: { [weak self] in
                 log.debug("startMicWorkItem start")
-                self?.startMicInputProvider(requestingFocus: false) { [weak self] (success) in
+                self?.startMicInputProvider(requestingFocus: false) { (success) in
                     guard success else {
                         log.debug("startMicWorkItem failed!")
                         return
                     }
-                    self?.startWakeUpDetector()
                 }
             })
             guard let startMicWorkItem = startMicWorkItem else { return }


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
