### PR TITLE
Handle exception on creating "AVAudioInputNode"

### DIFF
--- a/NuguClientKit/Sources/Audio/MicInputProvider/MicInputProvider.swift
+++ b/NuguClientKit/Sources/Audio/MicInputProvider/MicInputProvider.swift
@@ -100,10 +100,7 @@ public class MicInputProvider {
             inputNode = audioEngine.inputNode
             inputFormat = inputNode.inputFormat(forBus: audioBus)
         }) {
-            log.error("create AVAudioInputNode error: \(error)\n" +
-                "\t\tengine output format: \(audioEngine.inputNode.outputFormat(forBus: audioBus))\n" +
-                "\t\tengine input format: \(audioEngine.inputNode.inputFormat(forBus: audioBus))")
-            
+            log.error("create AVAudioInputNode error: \(error.localizedDescription)")
             throw error
         }
         


### PR DESCRIPTION
* You can't access the `InputNode` at that time. Because of `NSException`

## Check before PR

- [x] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
