### PR TITLE
Fix build error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "ReactiveX/RxSwift" ~> 5.0
+github "ReactiveX/RxSwift" ~> 6.0
 github "nugu-developers/natty-log-ios" ~> 1.0
 github "nugu-developers/silvertray-ios" ~> 1.0
 github "airbnb/lottie-ios" ~> 3.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 2.0
-github "Quick/Nimble" ~> 8.0
+github "Quick/Quick" ~> 3.0
+github "Quick/Nimble" ~> 9.0


### PR DESCRIPTION
* Xcode 12.5 can't build 'Nimble' version 8 or earlier

## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
