### PR TITLE
Use default server url if `registryServerUrl` doesn't exist on metadata

### DIFF
--- a/NuguClientKit/Sources/Configuration/ConfigurationStore.swift
+++ b/NuguClientKit/Sources/Configuration/ConfigurationStore.swift
@@ -198,7 +198,7 @@ public extension ConfigurationStore {
     func registryServerUrl(completion: @escaping (Result<String, Error>) -> Void) {
         configurationMetadata { result in
             guard case let .success(metadata) = result,
-                  let registryServerUrl = metadata.deviceGatewayRegistryUri else {
+                  let registryServerUrl = metadata.deviceGatewayRegistryUri ?? NuguServerInfo.registryServerAddress else {
                 completion(.failure(ConfigurationError.invalidUrl))
                 return
             }


### PR DESCRIPTION
## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
