### PR TITLE
Stop MicInput when the ASR is stopped

### DIFF
--- a/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
+++ b/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
@@ -267,12 +267,19 @@ extension SpeechRecognizerAggregator {
             if let state = SpeechRecognizerAggregatorState(notification.state) {
                 self.state = state
             }
-            if case .listening = notification.state {
+            
+            switch notification.state {
+            case .idle:
+                if self.useKeywordDetector {
+                    // if not restart here, keyword detector will be inactivated during tts speaking
+                    self.keywordDetector.start()
+                } else {
+                    self.stopMicInputProvider()
+                }
+            case .listening:
                 self.keywordDetector.stop()
-            }
-            // if not restarted here, keyword detector is inactive in tts speaking situation
-            if case .idle = notification.state, self.useKeywordDetector == true {
-                self.keywordDetector.start()
+            default:
+                break
             }
         }
     }


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
* If stopping mic routine triggered by  `AudioSesssionManager`, the mic-input will be lasting during TTS playing. because It triggers after All of Audio Input/Output finished.
* Refer to the restarting wakeup-detector routine, Stopping mic should be processed at that time.