### PR TITLE
Set error state to AsrResult rather then reset to nil When it could not prepared.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -301,10 +301,6 @@ public extension ASRAgent {
             if self.asrState != .idle {
                 self.asrResult = .cancel()
             }
-            
-            if self.asrRequest != nil {
-                self.asrResult = nil
-            }
         }
     }
 }
@@ -335,6 +331,9 @@ extension ASRAgent: FocusChannelDelegate {
                 self.asrResult = .cancel()
             case (_, .expectingSpeech):
                 self.asrResult = .cancelExpectSpeech
+            case (.nothing, .idle) where self.asrRequest != nil:
+                self.asrResult = .error(ASRError.listenFailed)
+                break
             // Ignore prepare
             default:
                 break

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -332,6 +332,7 @@ extension ASRAgent: FocusChannelDelegate {
             case (_, .expectingSpeech):
                 self.asrResult = .cancelExpectSpeech
             case (.nothing, .idle) where self.asrRequest != nil:
+                // It might be error when focusState is nothing And AsrRequest does exist.
                 self.asrResult = .error(ASRError.listenFailed)
                 break
             // Ignore prepare

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -319,7 +319,7 @@ extension ASRAgent: FocusChannelDelegate {
         asrDispatchQueue.async { [weak self] in
             guard let self = self else { return }
 
-            log.info("Focus:\(focusState) ASR:\(self.asrState)")
+            log.info("focus: \(focusState) asr state: \(self.asrState)")
             switch (focusState, self.asrState) {
             case (.foreground, let asrState) where [.idle, .expectingSpeech].contains(asrState):
                 self.executeStartCapture()


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
