### PR TITLE
Release focus when the audio player is stopped only.

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
@@ -396,11 +396,8 @@ extension AudioPlayerAgent: MediaPlayerDelegate {
             log.debug("check releasing focus is needed or not. state: \(audioPlayerState.debugDescription), isFocusedPlayer: \(self.latestPlayer === player)")
             if let audioPlayerState = audioPlayerState, self.latestPlayer === player {
                 self.audioPlayerState = audioPlayerState
-                switch audioPlayerState {
-                case .stopped, .finished:
+                if audioPlayerState == .stopped {
                     self.releaseFocusIfNeeded()
-                default:
-                    break
                 }
             }
             if let eventTypeInfo = eventTypeInfo {


### PR DESCRIPTION
## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
* Do not release the `focus` when the audio player is finished.
* Because state `finished` means current track is consumed and the next track will be played soon.
