### PR TITLE
Remasking `ASRAgent` version to 1.7

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -30,7 +30,7 @@ import RxSwift
 public final class ASRAgent: ASRAgentProtocol {
     // CapabilityAgentable
     // TODO: ASR interface version 1.1 -> ASR.Recognize(wakeup/power)
-    public var capabilityAgentProperty: CapabilityAgentProperty = CapabilityAgentProperty(category: .automaticSpeechRecognition, version: "1.6")
+    public var capabilityAgentProperty: CapabilityAgentProperty = CapabilityAgentProperty(category: .automaticSpeechRecognition, version: "1.7")
     private let playSyncProperty = PlaySyncProperty(layerType: .asr, contextType: .sound)
     
     // Private


### PR DESCRIPTION
* Some feature, applied on iOS already, should be applied to android.
* But, server side developer wants iOS SDK to make same version of android's.
