### PR TITLE
Add `referrerEvent` to `InteractionControl`

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent+Event.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent+Event.swift
@@ -34,8 +34,8 @@ extension DisplayAgent {
             case closeFailed
             case controlFocusSucceeded(direction: DisplayControlPayload.Direction)
             case controlFocusFailed(direction: DisplayControlPayload.Direction)
-            case controlScrollSucceeded(direction: DisplayControlPayload.Direction)
-            case controlScrollFailed(direction: DisplayControlPayload.Direction)
+            case controlScrollSucceeded(direction: DisplayControlPayload.Direction, interactionControl: InteractionControl?)
+            case controlScrollFailed(direction: DisplayControlPayload.Direction, interactionControl: InteractionControl?)
             case triggerChild(parentToken: String, data: [String: AnyHashable])
         }
     }
@@ -55,10 +55,16 @@ extension DisplayAgent.Event: Eventable {
                 payload["postback"] = postback
             }
         case .controlFocusSucceeded(let direction),
-             .controlFocusFailed(let direction),
-             .controlScrollSucceeded(let direction),
-             .controlScrollFailed(let direction):
+                .controlFocusFailed(let direction):
             payload["direction"] = direction
+        case .controlScrollSucceeded(let direction, let interactionControl),
+             .controlScrollFailed(let direction, let interactionControl):
+            payload["direction"] = direction
+            
+            if let interactionControl = interactionControl,
+               let interactionControlPayload = try? JSONEncoder().encode(interactionControl) {
+                payload["interactionControl"] = interactionControlPayload
+            }
         case .triggerChild(let parentToken, let data):
             payload["parentToken"] = parentToken
             payload["data"] = data

--- a/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
@@ -317,8 +317,9 @@ private extension DisplayAgent {
                         guard let self = self else { return }
                         switch state {
                         case .finished, .error:
+                            self.currentInteractionControl = nil
+                            
                             if let interactionControl = payload.interactionControl {
-                                self.currentInteractionControl = nil
                                 self.interactionControlManager.finish(mode: interactionControl.mode, category: self.capabilityAgentProperty.category)
                             }
                         default:

--- a/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Display/DisplayAgent.swift
@@ -38,6 +38,7 @@ public final class DisplayAgent: DisplayAgentProtocol {
     private let upstreamDataSender: UpstreamDataSendable
     private let sessionManager: SessionManageable
     private let interactionControlManager: InteractionControlManageable
+    private var currentInteractionControl: InteractionControl?
     
     private let displayDispatchQueue = DispatchQueue(label: "com.sktelecom.romaine.display_agent", qos: .userInitiated)
     private lazy var displayScheduler = SerialDispatchQueueScheduler(
@@ -286,20 +287,28 @@ private extension DisplayAgent {
                 guard let self = self, let delegate = self.delegate else { return }
                 guard let item = self.templateList.first(where: { $0.template.playServiceId == payload.playServiceId }) else {
                     self.sendCompactContextEvent(Event(
-                        typeInfo: .controlScrollFailed(direction: payload.direction),
+                        typeInfo: .controlScrollFailed(direction: payload.direction, interactionControl: payload.interactionControl),
                         playServiceId: payload.playServiceId,
                         referrerDialogRequestId: directive.header.dialogRequestId
                     ).rx)
                     return
                 }
                 if let interactionControl = payload.interactionControl {
+                    self.currentInteractionControl = interactionControl
                     self.interactionControlManager.start(mode: interactionControl.mode, category: self.capabilityAgentProperty.category)
                 }
                 delegate.displayAgentShouldScroll(templateId: item.templateId, direction: payload.direction, header: directive.header) { [weak self] scrollResult in
                     guard let self = self else { return }
-                    
                     self.playSyncManager.resetTimer(property: item.template.playSyncProperty)
-                    let typeInfo: Event.TypeInfo = scrollResult ? .controlScrollSucceeded(direction: payload.direction) : .controlScrollFailed(direction: payload.direction)
+                    
+                    var typeInfo: Event.TypeInfo {
+                        guard scrollResult else {
+                            return .controlScrollFailed(direction: payload.direction, interactionControl: payload.interactionControl)
+                        }
+                        
+                        return .controlScrollSucceeded(direction: payload.direction, interactionControl: payload.interactionControl)
+                    }
+                    
                     self.sendCompactContextEvent(Event(
                         typeInfo: typeInfo,
                         playServiceId: payload.playServiceId,
@@ -309,6 +318,7 @@ private extension DisplayAgent {
                         switch state {
                         case .finished, .error:
                             if let interactionControl = payload.interactionControl {
+                                self.currentInteractionControl = nil
                                 self.interactionControlManager.finish(mode: interactionControl.mode, category: self.capabilityAgentProperty.category)
                             }
                         default:

--- a/NuguAgents/Sources/CapabilityAgents/Interaction/InteractionControl.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Interaction/InteractionControl.swift
@@ -20,14 +20,32 @@
 
 import Foundation
 
-/// <#Description#>
+/**
+ interactionControl 필드를 포함하는 directive 에서 사용하는 자료구조
+ */
 public struct InteractionControl: Codable {
-    /// <#Description#>
+    /**
+     multi-turn 이 진행 중인가에 대한 정보
+     
+     (a)directive->(b)event 에 대한 응답 (c)directive 는 Play 구현에 의존하므로
+     (c) 가 내려올 수 있음을 클라이언트에 알려주기 위한 목적
+     */
     public let mode: Mode
     
-    /// <#Description#>
+    /**
+     전달받은 InteractionControl를 event 통해 전달하기위한 임시 저장소
+     */
+    public let referrerEvent: ReferrerEvent?
+    
     public enum Mode: String, Codable {
         case none = "NONE"
         case multiTurn = "MULTI_TURN"
+    }
+    
+    public struct ReferrerEvent: Codable {
+        /**
+         Event로 return해야 하는 agent의 type
+         */
+        public let type: String
     }
 }

--- a/NuguAgents/Sources/CapabilityAgents/Message/MessageAgent+Event.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Message/MessageAgent+Event.swift
@@ -29,7 +29,7 @@ extension MessageAgent {
         let referrerDialogRequestId: String?
         
         enum TypeInfo {
-            case candidatesListed
+            case candidatesListed(interactionControl: InteractionControl?)
             case sendMessageSucceeded(recipient: MessageAgentContact)
             case sendMessageFailed(recipient: MessageAgentContact, errorCode: String)
         }
@@ -43,8 +43,11 @@ extension MessageAgent.Event: Eventable {
         ]
         
         switch typeInfo {
-        case .candidatesListed:
-            break
+        case .candidatesListed(let interactionControl):
+            if let interactionControl = interactionControl,
+               let interactionControlPayload = try? JSONEncoder().encode(interactionControl) {
+                payload["interactionControl"] = interactionControlPayload
+            }
         case .sendMessageSucceeded(let recipient):
             if let recipientData = try? JSONEncoder().encode(recipient),
                 let recipientDictionary = try? JSONSerialization.jsonObject(with: recipientData, options: []) as? [String: AnyHashable] {

--- a/NuguAgents/Sources/CapabilityAgents/Message/MessageAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Message/MessageAgent.swift
@@ -99,12 +99,13 @@ public extension MessageAgent {
         return sendFullContextEvent(event.rx) { [weak self] state in
             completion?(state)
             
-            self?.messageDispatchQueue.async {
+            self?.messageDispatchQueue.async { [weak self] in
                 guard let self = self else { return }
                 switch state {
                 case .finished, .error:
+                    self.currentInteractionControl = nil
+                    
                     if let interactionControl = payload.interactionControl {
-                        self.currentInteractionControl = nil
                         self.interactionControlManager.finish(
                             mode: interactionControl.mode,
                             category: self.capabilityAgentProperty.category

--- a/NuguAgents/Sources/CapabilityAgents/PhoneCall/PhoneCallAgent+Event.swift
+++ b/NuguAgents/Sources/CapabilityAgents/PhoneCall/PhoneCallAgent+Event.swift
@@ -29,7 +29,7 @@ extension PhoneCallAgent {
         let referrerDialogRequestId: String?
         
         enum TypeInfo {
-            case candidatesListed
+            case candidatesListed(interactionControl: InteractionControl?)
             case makeCallFailed(errorCode: PhoneCallErrorCode, callType: PhoneCallType)
             case makeCallSucceeded(recipient: PhoneCallPerson)
         }
@@ -45,8 +45,11 @@ extension PhoneCallAgent.Event: Eventable {
         ]
         
         switch typeInfo {
-        case .candidatesListed:
-            break
+        case .candidatesListed(let interactionControl):
+            if let interactionControl = interactionControl,
+               let interactionControlPayload = try? JSONEncoder().encode(interactionControl) {
+                payload["interactionControl"] = interactionControlPayload
+            }
         case .makeCallFailed(let errorCode, let callType):
             payload["errorCode"] = errorCode.rawValue
             payload["callType"] = callType.rawValue

--- a/NuguAgents/Sources/CapabilityAgents/PhoneCall/PhoneCallAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/PhoneCall/PhoneCallAgent.swift
@@ -114,8 +114,9 @@ public extension PhoneCallAgent {
                 guard let self = self else { return }
                 switch state {
                 case .finished, .error:
+                    self.currentInteractionControl = nil
+                    
                     if let interactionControl = payload.interactionControl {
-                        self.currentInteractionControl = nil
                         self.interactionControlManager.finish(
                             mode: interactionControl.mode,
                             category: self.capabilityAgentProperty.category

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextAgent+Event.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextAgent+Event.swift
@@ -30,7 +30,7 @@ extension TextAgent {
         enum TypeInfo {
             case textInput(text: String, token: String?, attributes: [String: AnyHashable]?)
             case textSourceFailed(token: String, playServiceId: String?, errorCode: String)
-            case textRedirectFailed(token: String, playServiceId: String, errorCode: String)
+            case textRedirectFailed(token: String, playServiceId: String, errorCode: String, interactionControl: InteractionControl?)
         }
     }
 }
@@ -53,12 +53,17 @@ extension TextAgent.Event: Eventable {
                 "playServiceId": playServiceId,
                 "errorCode": errorCode
             ]
-        case .textRedirectFailed(let token, let playServiceId, let errorCode):
+        case .textRedirectFailed(let token, let playServiceId, let errorCode, let interactionControl):
             payload = [
                 "token": token,
                 "playServiceId": playServiceId,
                 "errorCode": errorCode
             ]
+            
+            if let interactionControl = interactionControl,
+               let interactionControlPayload = try? JSONEncoder().encode(interactionControl) {
+                payload["interactionControl"] = interactionControlPayload
+            }
         }
         
         return payload.compactMapValues { $0 }

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextAgentProtocol.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextAgentProtocol.swift
@@ -35,7 +35,7 @@ public protocol TextAgentProtocol: CapabilityAgentable {
     @discardableResult func requestTextInput(
         text: String,
         token: String?,
-        source: String?,
+        source: TextInputSource?,
         requestType: TextAgentRequestType,
         completion: ((StreamDataState) -> Void)?
     ) -> String
@@ -52,7 +52,7 @@ public extension TextAgentProtocol {
     @discardableResult func requestTextInput(
         text: String,
         token: String? = nil,
-        source: String? = nil,
+        source: TextInputSource? = nil,
         requestType: TextAgentRequestType
     ) -> String {
         return requestTextInput(
@@ -67,7 +67,7 @@ public extension TextAgentProtocol {
     @discardableResult func requestTextInput(
         text: String,
         token: String? = nil,
-        source: String? = nil,
+        source: TextInputSource? = nil,
         requestType: TextAgentRequestType,
         completion: ((StreamDataState) -> Void)?
     ) -> String {

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextInputSource.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextInputSource.swift
@@ -1,8 +1,8 @@
 //
-//  TextAgentSourceItem.swift
+//  TextInputSource.swift
 //  NuguAgents
 //
-//  Created by yonghoonKwon on 2020/03/05.
+//  Created by childc on 2022/08/16.
 //  Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +20,22 @@
 
 import Foundation
 
-struct TextAgentSourceItem: Decodable {
-    let text: String
-    let token: String
-    let playServiceId: String?
+public enum TextInputSource: CustomStringConvertible {
+    case user
+    case deepLink
+    case dynamic(_ source: String)
+    case unknown
+
+    public var description: String {
+        switch self {
+        case .user:
+            return "USERINPUT"
+        case .deepLink:
+            return "DEEPLINK"
+        case let .dynamic(source):
+            return source
+        default:
+            return "UNKNOWN"
+        }
+    }
 }

--- a/NuguClientKit/Sources/Client/NuguClient.swift
+++ b/NuguClientKit/Sources/Client/NuguClient.swift
@@ -445,7 +445,7 @@ public extension NuguClient {
     @discardableResult func requestTextInput(
         text: String,
         token: String? = nil,
-        source: String? = nil,
+        source: TextInputSource? = nil,
         requestType: TextAgentRequestType,
         completion: ((StreamDataState) -> Void)? = nil
     ) -> String {


### PR DESCRIPTION
* Then pass it to server during sending some events

## Check before PR

- [x] PR Title
- [x] Link issue or no issue to link
- [x] README.md
- [x] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
직전의 intercaction 상황을 textInput에 담아 전달하여 사용자가 Mic로 명령했는지, TextInput으로 명령했는지를 서버에서 가능할 수 있게 해준다.