### PR TITLE
Change api argument name from messageId to key 

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v5.0.1"
 github "ReactiveX/RxSwift" "6.5.0"
-github "airbnb/lottie-ios" "a89a677c17f1bbbb39df8b4a2488e3f92f649403"
+github "airbnb/lottie-ios" "314537ec697719fa33a9d48210f4d06a463286d3"
 github "nugu-developers/natty-log-ios" "1.2.3"

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -108,7 +108,7 @@ public final class ASRAgent: ASRAgentProtocol {
                 upstreamDataSender.cancelEvent(dialogRequestId: asrRequest.eventIdentifier.dialogRequestId)
                 sendCompactContextEvent(Event(
                     typeInfo: .stopRecognize,
-                    dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(messageId: expectSpeech!.messageId),
+                    dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(key: expectSpeech!.messageId),
                     referrerDialogRequestId: asrRequest.eventIdentifier.dialogRequestId
                 ).rx)
                 expectSpeech = nil
@@ -116,7 +116,7 @@ public final class ASRAgent: ASRAgentProtocol {
                 asrState = .idle
                 sendCompactContextEvent(Event(
                     typeInfo: .listenFailed,
-                    dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(messageId: expectSpeech!.messageId),
+                    dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(key: expectSpeech!.messageId),
                     referrerDialogRequestId: asrRequest.referrerDialogRequestId
                 ).rx)
                 expectSpeech = nil
@@ -126,21 +126,21 @@ public final class ASRAgent: ASRAgentProtocol {
                 case NetworkError.timeout:
                     sendCompactContextEvent(Event(
                         typeInfo: .responseTimeout,
-                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(messageId: expectSpeech!.messageId),
+                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(key: expectSpeech!.messageId),
                         referrerDialogRequestId: asrRequest.eventIdentifier.dialogRequestId
                     ).rx)
                 case ASRError.listeningTimeout:
                     upstreamDataSender.cancelEvent(dialogRequestId: asrRequest.eventIdentifier.dialogRequestId)
                     sendFullContextEvent(Event(
                         typeInfo: .listenTimeout,
-                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(messageId: expectSpeech!.messageId),
+                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(key: expectSpeech!.messageId),
                         referrerDialogRequestId: asrRequest.eventIdentifier.dialogRequestId
                     ).rx)
                 case ASRError.listenFailed:
                     upstreamDataSender.cancelEvent(dialogRequestId: asrRequest.eventIdentifier.dialogRequestId)
                     sendCompactContextEvent(Event(
                         typeInfo: .listenFailed,
-                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(messageId: expectSpeech!.messageId),
+                        dialogAttributes: expectSpeech?.messageId == nil ? nil : dialogAttributeStore.getAttributes(key: expectSpeech!.messageId),
                         referrerDialogRequestId: asrRequest.eventIdentifier.dialogRequestId
                     ).rx)
                 case ASRError.recognizeFailed:
@@ -170,7 +170,7 @@ public final class ASRAgent: ASRAgentProtocol {
                 interactionControlManager.start(mode: .multiTurn, category: capabilityAgentProperty.category)
             } else if let messageId = oldValue?.messageId {
                 playSyncManager.endPlay(property: playSyncProperty)
-                dialogAttributeStore.removeAttributes(messageId: messageId)
+                dialogAttributeStore.removeAttributes(key: messageId)
                 interactionControlManager.finish(mode: .multiTurn, category: capabilityAgentProperty.category)
             }
             if let dialogRequestId = oldValue?.dialogRequestId {
@@ -435,7 +435,7 @@ private extension ASRAgent {
                     "domainTypes": payload.domainTypes,
                     "playServiceId": payload.playServiceId
                 ]
-                self.dialogAttributeStore.setAttributes(attributes.compactMapValues { $0 }, messageId: directive.header.messageId)
+                self.dialogAttributeStore.setAttributes(attributes.compactMapValues { $0 }, key: directive.header.messageId)
             }
         }
     }
@@ -591,7 +591,7 @@ private extension ASRAgent {
         upstreamDataSender.sendStream(
             Event(
                 typeInfo: .recognize(initiator: asrRequest.initiator, options: asrRequest.options),
-                dialogAttributes: dialogAttributeStore.requestAttributes(messageId: expectSpeech?.messageId),
+                dialogAttributes: dialogAttributeStore.requestAttributes(key: expectSpeech?.messageId),
                 referrerDialogRequestId: asrRequest.referrerDialogRequestId
             ).makeEventMessage(
                 property: self.capabilityAgentProperty,

--- a/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AutomaticSpeechRecognition/ASRAgent.swift
@@ -151,13 +151,6 @@ public final class ASRAgent: ASRAgentProtocol {
                 expectSpeech = nil
             }
             
-            switch asrResult {
-            case .none, .complete, .error:
-                dialogAttributeStore.removeAllAttributes()
-            default:
-                break
-            }
-            
             post(NuguAgentNotification.ASR.Result(result: asrResult, dialogRequestId: asrRequest.eventIdentifier.dialogRequestId))
         }
     }

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextAgent.swift
@@ -353,10 +353,6 @@ private extension TextAgent {
                 referrerDialogRequestId: referrerDialogRequestId
             ).rx
         }
-        .do(onDispose: { [weak self] in
-            self?.expectTyping = nil
-        })
-
     }
 }
 

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextAgent.swift
@@ -64,18 +64,19 @@ public final class TextAgent: TextAgentProtocol {
     private var disposeBag = DisposeBag()
     private var expectTyping: TextAgentExpectTyping? {
         didSet {
-            guard oldValue?.messageId != expectTyping?.messageId else { return }
+            guard oldValue?.dialogRequestId != expectTyping?.dialogRequestId else { return }
             log.debug("expectTyping is changed from:\(oldValue?.dialogRequestId ?? "nil") to:\(expectTyping?.dialogRequestId ?? "nil")")
             
-            if let oldMessageId = oldValue?.messageId {
+            // TextAgent의 ExpectTyping은 함꼐 내려온 template에 종속적으로 동작해야 해서 messasgeId 대신 dialogRequestId를 사용한다.
+            if let oldDialogRequestId = oldValue?.dialogRequestId {
                 // Remove last attributes
-                dialogAttributeStore.removeAttributes(messageId: oldMessageId)
+                dialogAttributeStore.removeAttributes(key: oldDialogRequestId)
             }
             
-            if let messageId = expectTyping?.messageId,
+            if let dialogRequestId = expectTyping?.dialogRequestId,
                let payload = expectTyping?.payload.dictionary {
                 // Store attributes
-                dialogAttributeStore.setAttributes(payload.compactMapValues { $0 }, messageId: messageId)
+                dialogAttributeStore.setAttributes(payload.compactMapValues { $0 }, key: dialogRequestId)
             }
         }
     }
@@ -130,10 +131,6 @@ extension TextAgent {
             completion: completion
         )
         .dialogRequestId
-    }
-    
-    public func clearAttributes() {
-        dialogAttributeStore.removeAllAttributes()
     }
 }
 
@@ -325,8 +322,8 @@ private extension TextAgent {
                     
                     var attributes = [String: AnyHashable]()
                     if case .dialog = requestType,
-                       let expectTypingMessageId = self?.expectTyping?.messageId,
-                       let expectTypingAttribute = self?.dialogAttributeStore.requestAttributes(messageId: expectTypingMessageId) {
+                       let expectTypingDialogRequestId = self?.expectTyping?.dialogRequestId,
+                       let expectTypingAttribute = self?.dialogAttributeStore.requestAttributes(key: expectTypingDialogRequestId) {
                         attributes.merge(expectTypingAttribute)
                     }
                     

--- a/NuguAgents/Sources/CapabilityAgents/Text/TextAgentProtocol.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Text/TextAgentProtocol.swift
@@ -39,11 +39,6 @@ public protocol TextAgentProtocol: CapabilityAgentable {
         requestType: TextAgentRequestType,
         completion: ((StreamDataState) -> Void)?
     ) -> String
-    
-    /**
-     Clear All attributes for mult-turn
-     */
-    func clearAttributes()
 }
 
 // MARK: - Default

--- a/NuguAgents/Sources/Dialog/DialogAttributeStore.swift
+++ b/NuguAgents/Sources/Dialog/DialogAttributeStore.swift
@@ -33,11 +33,11 @@ public final class DialogAttributeStore: DialogAttributeStoreable {
     
     public init() {}
     
-    public func setAttributes(_ attributes: [String: AnyHashable], messageId: String) {
-        _attributeDic.mutate { $0[messageId] = attributes }
+    public func setAttributes(_ attributes: [String: AnyHashable], key: String) {
+        _attributeDic.mutate { $0[key] = attributes }
     }
     
-    public func requestAttributes(messageId: String? = nil) -> [String: AnyHashable]? {
+    public func requestAttributes(key: String? = nil) -> [String: AnyHashable]? {
         var lastingAttributes: [String: AnyHashable]? {
             guard let key = attributeDic.keys.first else {
                 return nil
@@ -46,20 +46,20 @@ public final class DialogAttributeStore: DialogAttributeStoreable {
             return attributeDic[key] as? [String: AnyHashable]
         }
         
-        guard let messageId = messageId else {
+        guard let key = key else {
             return lastingAttributes
         }
 
-        let specificAttributes = attributeDic[messageId] as? [String: AnyHashable]
+        let specificAttributes = attributeDic[key] as? [String: AnyHashable]
         return specificAttributes ?? lastingAttributes
     }
     
-    public func getAttributes(messageId: String) -> [String: AnyHashable]? {
-        attributeDic[messageId] as? [String: AnyHashable]
+    public func getAttributes(key: String) -> [String: AnyHashable]? {
+        attributeDic[key] as? [String: AnyHashable]
     }
     
-    public func removeAttributes(messageId: String) {
-        _attributeDic.mutate { $0[messageId] = nil }
+    public func removeAttributes(key: String) {
+        _attributeDic.mutate { $0[key] = nil }
     }
     
     public func removeAllAttributes() {

--- a/NuguAgents/Sources/Dialog/DialogAttributeStoreable.swift
+++ b/NuguAgents/Sources/Dialog/DialogAttributeStoreable.swift
@@ -26,24 +26,24 @@ public protocol DialogAttributeStoreable: AnyObject, TypedNotifyable {
     /**
      Get specific attributes or nil
      */
-    func getAttributes(messageId: String) -> [String: AnyHashable]?
+    func getAttributes(key: String) -> [String: AnyHashable]?
     
     /**
      Set attributes
      */
-    func setAttributes(_ attributes: [String: AnyHashable], messageId: String)
+    func setAttributes(_ attributes: [String: AnyHashable], key: String)
     
     /**
      Request specific attributes.
      
      It returns one of lasting attributes if there's no exact attributes
      */
-    func requestAttributes(messageId: String?) -> [String: AnyHashable]?
+    func requestAttributes(key: String?) -> [String: AnyHashable]?
     
     /**
      Remove specific attributes for multi-turn
      */
-    func removeAttributes(messageId: String)
+    func removeAttributes(key: String)
     
     /**
      Remove All attributes for multi-turn

--- a/NuguTests/Mock/MockDialogAttributeStore.swift
+++ b/NuguTests/Mock/MockDialogAttributeStore.swift
@@ -23,18 +23,18 @@ import Foundation
 import NuguAgents
 
 class MockDialogAttributeStore: DialogAttributeStoreable {
-    func getAttributes(messageId: String) -> [String: AnyHashable]? {
+    func getAttributes(key: String) -> [String: AnyHashable]? {
         return nil
     }
     
-    func setAttributes(_ attributes: [String: AnyHashable], messageId: String) {
+    func setAttributes(_ attributes: [String: AnyHashable], key: String) {
     }
     
-    func requestAttributes(messageId: String?) -> [String: AnyHashable]? {
+    func requestAttributes(key: String?) -> [String: AnyHashable]? {
         return nil
     }
     
-    func removeAttributes(messageId: String) {
+    func removeAttributes(key: String) {
     }
     
     func removeAllAttributes() {

--- a/NuguTests/NuguAgents/Dialog/DialogAttributeStoreSpec.swift
+++ b/NuguTests/NuguAgents/Dialog/DialogAttributeStoreSpec.swift
@@ -28,7 +28,7 @@ class DialogAttributeStoreSpec: QuickSpec {
             
             context("request attributes") {
                 it("attributes not found") {
-                    expect(sut.requestAttributes(messageId: nil)).to(beNil())
+                    expect(sut.requestAttributes(key: nil)).to(beNil())
                 }
             }
         }
@@ -39,7 +39,7 @@ class DialogAttributeStoreSpec: QuickSpec {
             let expectedMessageId = "expectedMessageId"
             beforeEach {
                 sut = DialogAttributeStore()
-                sut.setAttributes(expectedAttributes, messageId: expectedMessageId)
+                sut.setAttributes(expectedAttributes, key: expectedMessageId)
             }
             
             afterEach {
@@ -48,32 +48,32 @@ class DialogAttributeStoreSpec: QuickSpec {
             
             context("request attributes") {
                 it("get the attributes") {
-                    expect(sut.requestAttributes(messageId: expectedMessageId)).to(equal(expectedAttributes))
+                    expect(sut.requestAttributes(key: expectedMessageId)).to(equal(expectedAttributes))
                 }
             }
             
             context("request attributes by wrong messageId") {
                 it("get last set attributes") {
-                    expect(sut.requestAttributes(messageId: "wrong messageId")).to(equal(expectedAttributes))
+                    expect(sut.requestAttributes(key: "wrong messageId")).to(equal(expectedAttributes))
                 }
             }
             
             context("request attributes by nil messageId") {
                 it("get last set attributes") {
-                    expect(sut.requestAttributes(messageId: nil)).to(equal(expectedAttributes))
+                    expect(sut.requestAttributes(key: nil)).to(equal(expectedAttributes))
                 }
             }
             
             it("get the attributes") {
-                expect(sut.getAttributes(messageId: expectedMessageId)).to(equal(expectedAttributes))
+                expect(sut.getAttributes(key: expectedMessageId)).to(equal(expectedAttributes))
             }
             
             context("remove attributes") {
                 beforeEach {
-                    sut.removeAttributes(messageId: expectedMessageId)
+                    sut.removeAttributes(key: expectedMessageId)
                 }
                 it("attributes not found") {
-                    expect(sut.requestAttributes(messageId: nil)).to(beNil())
+                    expect(sut.requestAttributes(key: nil)).to(beNil())
                 }
             }
             
@@ -82,7 +82,7 @@ class DialogAttributeStoreSpec: QuickSpec {
                     sut.removeAllAttributes()
                 }
                 it("attributes not found") {
-                    expect(sut.requestAttributes(messageId: nil)).to(beNil())
+                    expect(sut.requestAttributes(key: nil)).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
* DialogAttribute의 key가 messageId를 강제하지 않도록 수정됨에 따라 코드 반영
* DialogAttribute를 ASR/TextInput 요청상태에서 reset하지 않고, template 표출 시점에 판단하도록 수정