### PR TITLE
Remove `active` checking logic on `startMicInputProvider`.

### DIFF
--- a/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
+++ b/NuguClientKit/Sources/Audio/SpeechRecognizerAggregator.swift
@@ -175,10 +175,6 @@ public extension SpeechRecognizerAggregator {
     func startMicInputProvider(requestingFocus: Bool, completion: @escaping (Bool) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            guard UIApplication.shared.applicationState == .active else {
-                completion(false)
-                return
-            }
             
             AVAudioSession.sharedInstance().requestRecordPermission { [weak self] isGranted in
                 guard let self = self else { return }


### PR DESCRIPTION
- Client(App.) should do this if needed.

## Check before PR

- [x] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [x] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
