### PR TITLE
move 액션이 일어났을 때 routine이 playing 상태가 아닌 경우, actionWorkItem을 cancel 하도록 수정

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/Routine/RoutineExecuter.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Routine/RoutineExecuter.swift
@@ -191,6 +191,7 @@ class RoutineExecuter {
             }
             
             if [.interrupted, .suspended].contains(self.state) {
+                self.actionWorkItem?.cancel()
                 self.state = .playing
             }
             


### PR DESCRIPTION
## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary

move 액션이 일어났을 때 routine이 playing 상태가 아닌 경우, actionWorkItem을 cancel 하도록 수정