### PR TITLE
loginKit 의 presentAuthorize 에서 deviceUniqueId 를 "deviceUniqueId" 잘 못 넘기고 있는 이슈 수정

### DIFF
--- a/NuguLoginKit/Sources/Business/NuguOAuthClient.swift
+++ b/NuguLoginKit/Sources/Business/NuguOAuthClient.swift
@@ -339,7 +339,7 @@ private extension NuguOAuthClient {
         }
         
         let data: [String: String] = [
-            "deviceSerialNumber": "deviceUniqueId",
+            "deviceSerialNumber": deviceUniqueId,
             "theme": theme.rawValue
         ].merged(with: additionalQueryData)
         


### PR DESCRIPTION
## Check before PR

- [x] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
deviceUniqueId 의 값을 넘겨줘야 하는데 "deviceUniqueId" 으로 넘기고 있어서 수정함. 