### PR TITLE
직접 다루지 않는 cancelAll이 들어왔을 때 stop이 아닌, interrupt 상태로 변경

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/Routine/RoutineExecuter.swift
+++ b/NuguAgents/Sources/CapabilityAgents/Routine/RoutineExecuter.swift
@@ -224,7 +224,7 @@ private extension RoutineExecuter {
                     if self.handlingDirectives.contains(notification.directive.header.messageId) {
                         self.doNextAction()
                     } else {
-                        self.doStop()
+                        self.doInterrupt()
                     }
                     
                     self.handlingDirectives.removeAll()


### PR DESCRIPTION
## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
- 직접 다루지 않는 cancelAll이 들어왔을 때 stop이 아닌, interrupt 상태로 변경
