### PR TITLE
Template2 파싱 로직 추가

### DIFF
--- a/NuguClientKit/Sources/Audio/ControlCenterManager.swift
+++ b/NuguClientKit/Sources/Audio/ControlCenterManager.swift
@@ -197,6 +197,12 @@ private extension ControlCenterManager {
                 return nil
             }
             return (payload.template.content.title, payload.template.content.subtitle1, payload.template.content.subtitle2, payload.template.content.imageUrl)
+        case "AudioPlayer.Template2":
+            guard let payload = try? JSONDecoder().decode(AudioPlayer2Template.self, from: payloadAsData) else {
+                remove()
+                return nil
+            }
+            return (payload.template.content.title, payload.template.content.subtitle, payload.template.content.subtitle1, payload.template.content.imageUrl)
         default:
             remove()
             return nil


### PR DESCRIPTION
## Check before PR

- [ ] PR Title
- [ ] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [ ] Update minor
- [ ] Update patch

## Need when updating version

- [ ] NUGU Developers
- [ ] Github Wiki

## Summary
- Template2 모델이 추가됨으로 인해 Template2 파싱로직 추가
- 앱 잠금화면, NotificationCenter 진입시 보이는 컨트롤창에 노출될 데이터들을 위해 필요