### PR TITLE
직렬화 시도할 때 발생할 수 있는 OBJC Exception 처리

### DIFF
--- a/NuguCore/Sources/StreamData/Model/Upstream.swift
+++ b/NuguCore/Sources/StreamData/Model/Upstream.swift
@@ -156,9 +156,11 @@ extension Upstream.Event {
         
         var contextString: String = ""
         if let error = UnifiedErrorCatcher.try ({
-            if let data = try? JSONSerialization.data(withJSONObject: contextDict.compactMapValues { $0 }, options: []),
-               let serializedContextString = String(data: data, encoding: .utf8) {
-                contextString = serializedContextString
+            do {
+                let data = try JSONSerialization.data(withJSONObject: contextDict.compactMapValues { $0 }, options: [])
+                contextString = String(data: data, encoding: .utf8) ?? ""
+            } catch {
+                return error
             }
             
             return nil

--- a/NuguCore/Sources/StreamData/Model/Upstream.swift
+++ b/NuguCore/Sources/StreamData/Model/Upstream.swift
@@ -20,6 +20,9 @@
 
 import Foundation
 
+import NuguUtils
+import NuguObjcUtils
+
 /// An enum that contains the data structures to be send to the server.
 public enum Upstream {
     /// A structure that contains a event and contexts.
@@ -151,10 +154,16 @@ extension Upstream.Event {
             "client": client
         ]
         
-        guard
-            let data = try? JSONSerialization.data(withJSONObject: contextDict.compactMapValues { $0 }, options: []),
-            let contextString = String(data: data, encoding: .utf8) else {
-                return ""
+        var contextString: String = ""
+        if let error = UnifiedErrorCatcher.try ({
+            if let data = try? JSONSerialization.data(withJSONObject: contextDict.compactMapValues { $0 }, options: []),
+               let serializedContextString = String(data: data, encoding: .utf8) {
+                contextString = serializedContextString
+            }
+            
+            return nil
+        }) {
+            log.error("context dictionary includes unserializable object. error: \(error)")
         }
         
         return contextString

--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
         ),
         .target(
             name: "NuguCore",
-            dependencies: ["NuguUtils", "NattyLog"],
+            dependencies: ["NuguUtils", "NuguObjcUtils", "NattyLog"],
             path: "NuguCore/",
             exclude: ["Info.plist", "README.md"]
         ),


### PR DESCRIPTION
## Description
- 직렬화를 지원하지 않는 객체에 대해서 NSException이 발생하는데, 이것을 처리하지 않으면 crash가 발생합니다
- 직렬화 가능한 객체만 받도록 할 수는 없고, 실패에 대해 crash를 회피하는 정도의 처리만 가능합니다.