### PR TITLE
Server sent event (directive) 시작/종료에 대한 순서를 보장한다

### DIFF
--- a/NuguClientKit/Sources/Client/NuguClient.swift
+++ b/NuguClientKit/Sources/Client/NuguClient.swift
@@ -432,8 +432,8 @@ public extension NuguClient {
                     completion?(.error(error))
                 case .success(let url):
                     NuguServerInfo.registryServerAddress = url
-                    self?.streamDataRouter.startReceiveServerInitiatedDirective(completion: { state in
-                        sema.signal()
+                    self?.streamDataRouter.startReceiveServerInitiatedDirective(completion: { [weak sema] state in
+                        sema?.signal()
                         completion?(state)
                     })
                 }

--- a/NuguClientKit/Sources/Client/NuguClient.swift
+++ b/NuguClientKit/Sources/Client/NuguClient.swift
@@ -279,6 +279,7 @@ public class NuguClient {
     private var pausedByInterruption = false
     private let backgroundFocusHolder: BackgroundFocusHolder
     private var audioDeactivateWorkItem: DispatchWorkItem?
+    private let directiveConnectionQueue = DispatchQueue(label: "com.sktelecom.romaine.NuguClientKit.directive_connection")
     
     init(
         contextManager: ContextManageable,
@@ -422,14 +423,22 @@ public extension NuguClient {
      The server can send some directives at certain times.
      */
     func startReceiveServerInitiatedDirective(completion: ((StreamDataState) -> Void)? = nil) {
-        ConfigurationStore.shared.registryServerUrl { [weak self] result in
-            switch result {
-            case .failure(let error):
-                completion?(.error(error))
-            case .success(let url):
-                NuguServerInfo.registryServerAddress = url
-                self?.streamDataRouter.startReceiveServerInitiatedDirective(completion: completion)
+        directiveConnectionQueue.async { [weak self] in
+            let sema = DispatchSemaphore(value: .zero)
+            ConfigurationStore.shared.registryServerUrl { [weak self] result in
+                switch result {
+                case .failure(let error):
+                    sema.signal()
+                    completion?(.error(error))
+                case .success(let url):
+                    NuguServerInfo.registryServerAddress = url
+                    self?.streamDataRouter.startReceiveServerInitiatedDirective(completion: { state in
+                        sema.signal()
+                        completion?(state)
+                    })
+                }
             }
+            sema.wait()
         }
     }
     
@@ -437,7 +446,9 @@ public extension NuguClient {
      Stop receiving server-initiated-directive.
      */
     func stopReceiveServerInitiatedDirective() {
-        streamDataRouter.stopReceiveServerInitiatedDirective()
+        directiveConnectionQueue.async { [weak self] in
+            self?.streamDataRouter.stopReceiveServerInitiatedDirective()
+        }
     }
     
     /// Send event that needs a text-based recognition

--- a/NuguCore/Sources/StreamData/StreamDataRouter.swift
+++ b/NuguCore/Sources/StreamData/StreamDataRouter.swift
@@ -261,6 +261,7 @@ extension StreamDataRouter {
                 
                 directiveSequencer.processDirective(directive)
                 completion?(.received(part: directive))
+                serverInitiatedDirectiveCompletion?(.received(part: directive))
             }
         } else if let attachment = Downstream.Attachment(headerDictionary: part.header, body: part.body) {
             log.debug("Attachment: \(attachment.header.dialogRequestId), \(attachment.header.type)")

--- a/NuguCore/Sources/StreamData/StreamDataRouter.swift
+++ b/NuguCore/Sources/StreamData/StreamDataRouter.swift
@@ -60,6 +60,10 @@ public extension StreamDataRouter {
         serverInitiatedDirectiveStateDisposable = serverInitiatedDirectiveReceiver.stateObserver
             .subscribe(onNext: { [weak self] state in
                 self?.notificationQueue.async { [weak self] in
+                    if state == .connected {
+                        completion?(.prepared)
+                    }
+                    
                     self?.post(state)
                 }
             })
@@ -75,6 +79,7 @@ public extension StreamDataRouter {
                 completion?(.error($0))
             }, onDisposed: {
                 log.debug("server initiated directive is stopeed")
+                completion?(.finished)
             })
         serverInitiatedDirectiveDisposable?.disposed(by: disposeBag)
     }


### PR DESCRIPTION
## Description
- `startReceiveServerInitiatedDirective` / `stopReceiveServerInitiatedDirective`의 호출 순서에 따라 동작을 완결성 있게 수행한다.

## Focus
- `Semaphore`를 이용한 순서보장 로직
- `Semaphore`객체를 promote하지 않아 signal이 계속 수행되는 것을 막는다