### PR TITLE
AudioPlayer DelayEvent 시간 ceil이 아닌 floor로 처리하도록 변경

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayer.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayer.swift
@@ -259,7 +259,7 @@ private extension AudioPlayer {
                       seconds.isInfinite == false else {
                     return 0
                 }
-                return Int(ceil(seconds))
+                return Int(floor(seconds))
             })
             .filter { [weak self] offset in
                 guard let self = self else { return false }


### PR DESCRIPTION
## Check before PR
- [x] PR Title
- [x] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Version

- [ ] Update major
- [x] Update minor
- [ ] Update patch

## Need when updating version

- [x] NUGU Developers
- [ ] Github Wiki

## Summary
- audioPlayer가 delay된 Report를 보낼떄 설정한 시간대보다 0.5~0.8초정도 빠르게 보내는 현상 수정
   - offset을 ceil(올림)하고 있어서 60초 딜레이로 설정된 이벤트가 59.x초에 가고있어 이를 floor로 바꿈
