### PR TITLE
ProgressReportDelayElapsed 재생중에 한번만 전송하도록 처리

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayer.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayer.swift
@@ -64,6 +64,7 @@ final class AudioPlayer {
     private var lastReportedOffset: Int = 0
     
     private var lastDataAppended = false
+    private var canReportDelayEvent: Bool = true
     
     init(directive: Downstream.Directive) throws {
         payload = try JSONDecoder().decode(AudioPlayerPlayPayload.self, from: directive.payload)
@@ -277,7 +278,8 @@ private extension AudioPlayer {
                 
                 // Check if there is any report target between last offset and current offset.
                 let offsetRange = (self.lastReportedOffset + 1...offset)
-                if delayReportTime > 0, offsetRange.contains(delayReportTime) {
+                if delayReportTime > 0, offsetRange.contains(delayReportTime), canReportDelayEvent {
+                    self.canReportDelayEvent = false
                     self.progressDelegate?.audioPlayerDidReportDelay(self)
                 }
                 if intervalReportTime > 0, offsetRange.contains(intervalReportTime * (self.lastReportedOffset / intervalReportTime + 1)) {


### PR DESCRIPTION
## Check before PR
- [x] PR Title
- [x] Link issue or no issue to link
- [ ] README.md
- [ ] Code-level documentation

## Summary
- ProgressReportDelayElapsed 재생중에 한번만 전송하도록 처리 
   - Seek중에 특정시간 이후 -> 특정시간 이전 -> 특정시간 이후를 반복하면 ProgressReportDelayElapsed 를 연속해서 전송하는 현상 발생
   - 재생중에 한번만 전송하도록 적용