### PR TITLE
`ServerSentEvent`의 state와 PingDisposable의 Race condition 해결

### DIFF
--- a/NuguClientKit/Sources/Client/NuguClientDelegate.swift
+++ b/NuguClientKit/Sources/Client/NuguClientDelegate.swift
@@ -27,7 +27,7 @@ public typealias Directive = Downstream.Directive
 public typealias DirectiveAttachment = Downstream.Attachment
 public typealias Event = Upstream.Event
 public typealias EventAttachment = Upstream.Attachment
-public typealias ServerSideEventReceiverState = NuguCore.ServerSideEventReceiverState
+public typealias ServerSentEventReceiverState = NuguCore.ServerSentEventReceiverState
 
 public protocol NuguClientDelegate: AnyObject {
     // authorization related
@@ -80,8 +80,8 @@ public protocol NuguClientDelegate: AnyObject {
     func nuguClientDidSend(attachment: EventAttachment, error: Error?)
     
     /// Notify that nugu client server initiated directive state has been changed
-    /// - Parameter state: ServerSideEventReceiverState
-    func nuguClientServerInitiatedDirectiveRecevierStateDidChange(_ state: ServerSideEventReceiverState)
+    /// - Parameter state: ServerSentEventReceiverState
+    func nuguClientServerInitiatedDirectiveRecevierStateDidChange(_ state: ServerSentEventReceiverState)
     
     func nuguClientRequestRecognitionWithTriggerContext() -> [String: AnyHashable]
 }
@@ -110,6 +110,6 @@ public extension NuguClientDelegate {
     func nuguClientWillSend(event: Event) {}
     func nuguClientDidSend(event: Event, error: Error?) {}
     func nuguClientDidSend(attachment: EventAttachment, error: Error?) {}
-    func nuguClientServerInitiatedDirectiveRecevierStateDidChange(_ state: ServerSideEventReceiverState) {}
+    func nuguClientServerInitiatedDirectiveRecevierStateDidChange(_ state: ServerSentEventReceiverState) {}
     func nuguClientRequestRecognitionWithTriggerContext() -> [String: AnyHashable] { [:] }
 }

--- a/NuguCore/Sources/Network/Api/ServerSentEventProcessor.swift
+++ b/NuguCore/Sources/Network/Api/ServerSentEventProcessor.swift
@@ -1,5 +1,5 @@
 //
-//  ServerSideEventProcessor.swift
+//  ServerSentEventProcessor.swift
 //  NuguCore
 //
 //  Created by childc on 2020/03/04.
@@ -22,7 +22,7 @@ import Foundation
 
 import RxSwift
 
-class ServerSideEventProcessor: MultiPartProcessable {
+class ServerSentEventProcessor: MultiPartProcessable {
     var parser: MultiPartParser?
     var data = Data()
     let subject = PublishSubject<Data>()

--- a/NuguCore/Sources/StreamData/ServerSentEventReceiver.swift
+++ b/NuguCore/Sources/StreamData/ServerSentEventReceiver.swift
@@ -1,5 +1,5 @@
 //
-//  ServerSideEventReceiver.swift
+//  ServerSentEventReceiver.swift
 //  NuguCore
 //
 //  Created by childc on 2020/03/05.
@@ -22,14 +22,14 @@ import Foundation
 
 import RxSwift
 
-class ServerSideEventReceiver {
+class ServerSentEventReceiver {
     private let apiProvider: NuguApiProvider
     private var pingDisposable: Disposable?
-    private let stateSubject = PublishSubject<ServerSideEventReceiverState>()
-    private let sseStateQueue = DispatchQueue(label: "com.sktelecom.romaine.core.serve_sent_event_state")
+    private let stateSubject = PublishSubject<ServerSentEventReceiverState>()
+    private let sseStateQueue = DispatchQueue(label: "com.sktelecom.romaine.core.server_sent_event_state")
     private let disposeBag = DisposeBag()
     
-    private(set) var state: ServerSideEventReceiverState = .unconnected {
+    private(set) var state: ServerSentEventReceiverState = .unconnected {
         didSet {
             if oldValue != state {
                 log.debug("server side event receiver state changed from: \(oldValue) to: \(state)")
@@ -75,14 +75,14 @@ class ServerSideEventReceiver {
             })
     }
 
-    var stateObserver: Observable<ServerSideEventReceiverState> {
+    var stateObserver: Observable<ServerSentEventReceiverState> {
         return stateSubject
     }
 }
 
 // MARK: - ping
 
-private extension ServerSideEventReceiver {
+private extension ServerSentEventReceiver {
     private enum Const {
         static let minPingInterval = 180
         static let maxPingInterval = 300

--- a/NuguCore/Sources/StreamData/ServerSentEventReceiverState.swift
+++ b/NuguCore/Sources/StreamData/ServerSentEventReceiverState.swift
@@ -1,5 +1,5 @@
 //
-//  ServerSideEventReceiverState.swift
+//  ServerSentEventReceiverState.swift
 //  NuguCore
 //
 //  Created by childc on 2020/03/10.
@@ -22,8 +22,8 @@ import Foundation
 
 import NuguUtils
 
-public enum ServerSideEventReceiverState: Equatable, EnumTypedNotification {
-    public static var name: Notification.Name = .serverSideEventReceiverStateDidChange
+public enum ServerSentEventReceiverState: Equatable, EnumTypedNotification {
+    public static var name: Notification.Name = .serverSentEventReceiverStateDidChange
     
     /// Didn't try to connect to server or connection reset
     case unconnected
@@ -38,7 +38,7 @@ public enum ServerSideEventReceiverState: Equatable, EnumTypedNotification {
     /// - Parameter error: If Connection closed because of the error.
     case disconnected(error: Error)
     
-    public static func == (lhs: ServerSideEventReceiverState, rhs: ServerSideEventReceiverState) -> Bool {
+    public static func == (lhs: ServerSentEventReceiverState, rhs: ServerSentEventReceiverState) -> Bool {
         switch (lhs, rhs) {
         case (.unconnected, .unconnected),
             (.connected, .connected),
@@ -55,5 +55,5 @@ public enum ServerSideEventReceiverState: Equatable, EnumTypedNotification {
 }
 
 extension Notification.Name {
-    static let serverSideEventReceiverStateDidChange = Notification.Name("com.sktelecom.romaine.notification.name.server_side_event_receiver_state_did_change")
+    static let serverSentEventReceiverStateDidChange = Notification.Name("com.sktelecom.romaine.notification.name.server_sent_event_receiver_state_did_change")
 }

--- a/NuguCore/Sources/StreamData/StreamDataRouter.swift
+++ b/NuguCore/Sources/StreamData/StreamDataRouter.swift
@@ -31,14 +31,14 @@ public class StreamDataRouter: StreamDataRoutable {
     private let directiveSequencer: DirectiveSequenceable
     @Atomic private var eventSenders = [String: EventSender]()
     @Atomic private var eventDisposables = [String: Disposable]()
-    private var serverInitiatedDirectiveReceiver: ServerSideEventReceiver
+    private var serverInitiatedDirectiveReceiver: ServerSentEventReceiver
     private var serverInitiatedDirectiveCompletion: ((StreamDataState) -> Void)?
     private var serverInitiatedDirectiveDisposable: Disposable?
     private var serverInitiatedDirectiveStateDisposable: Disposable?
     private let disposeBag = DisposeBag()
     
     public init(directiveSequencer: DirectiveSequenceable) {
-        serverInitiatedDirectiveReceiver = ServerSideEventReceiver(apiProvider: nuguApiProvider)
+        serverInitiatedDirectiveReceiver = ServerSentEventReceiver(apiProvider: nuguApiProvider)
         self.directiveSequencer = directiveSequencer
     }
 }
@@ -408,6 +408,6 @@ public extension NuguCoreNotification {
             }
         }
         
-        public typealias ServerInitiatedDirectiveReceiverState = ServerSideEventReceiverState
+        public typealias ServerInitiatedDirectiveReceiverState = ServerSentEventReceiverState
     }
 }

--- a/nugu-ios.xcodeproj/project.pbxproj
+++ b/nugu-ios.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 		7345DFF325C68B3A006DBCC6 /* DataBoundInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7345DFF225C68B3A006DBCC6 /* DataBoundInputStream.swift */; };
 		7352F19A2A37225600B0199C /* UIImage+resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7352F1992A37225600B0199C /* UIImage+resize.swift */; };
 		735A4CBE241172F1004E7A41 /* EventResponseProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CBA241172F0004E7A41 /* EventResponseProcessor.swift */; };
-		735A4CBF241172F1004E7A41 /* ServerSideEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CBB241172F0004E7A41 /* ServerSideEventProcessor.swift */; };
+		735A4CBF241172F1004E7A41 /* ServerSentEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CBB241172F0004E7A41 /* ServerSentEventProcessor.swift */; };
 		735A4CC0241172F1004E7A41 /* NuguApiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CBC241172F0004E7A41 /* NuguApiProvider.swift */; };
 		735A4CC1241172F1004E7A41 /* NuguApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CBD241172F1004E7A41 /* NuguApi.swift */; };
 		735A4CC624117339004E7A41 /* MultiPartParserError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A4CC424117338004E7A41 /* MultiPartParserError.swift */; };
@@ -361,8 +361,8 @@
 		7378FDD925B8191200AB9764 /* TypedNotifyable+post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7378FDD825B8191200AB9764 /* TypedNotifyable+post.swift */; };
 		738224BE26D4DB5D0050D67A /* DataStreamPlayerBufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738224BD26D4DB5D0050D67A /* DataStreamPlayerBufferState.swift */; };
 		7386DA9923CF279C002BF24C /* NuguClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7386DA9823CF279C002BF24C /* NuguClientDelegate.swift */; };
-		739078FD241A3E0C007D753F /* ServerSideEventReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739078FB241A3E0B007D753F /* ServerSideEventReceiver.swift */; };
-		739078FE241A3E0C007D753F /* ServerSideEventReceiverState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739078FC241A3E0C007D753F /* ServerSideEventReceiverState.swift */; };
+		739078FE241A3E0C007D753F /* ServerSentEventReceiverState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739078FC241A3E0C007D753F /* ServerSentEventReceiverState.swift */; };
+		73A76A5A2B6B942C007F4178 /* ServerSentEventReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A76A592B6B942C007F4178 /* ServerSentEventReceiver.swift */; };
 		73A84E3B2799990200133D45 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C256AA269740BB0008FE7F /* RxSwift.xcframework */; };
 		73A84E3C2799990200133D45 /* RxSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 73C256AA269740BB0008FE7F /* RxSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		73BF06DE26A0208700112473 /* NuguObjcUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 73BF06DC26A0208700112473 /* NuguObjcUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1089,7 +1089,7 @@
 		7345DFF225C68B3A006DBCC6 /* DataBoundInputStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataBoundInputStream.swift; sourceTree = "<group>"; };
 		7352F1992A37225600B0199C /* UIImage+resize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+resize.swift"; sourceTree = "<group>"; };
 		735A4CBA241172F0004E7A41 /* EventResponseProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventResponseProcessor.swift; sourceTree = "<group>"; };
-		735A4CBB241172F0004E7A41 /* ServerSideEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSideEventProcessor.swift; sourceTree = "<group>"; };
+		735A4CBB241172F0004E7A41 /* ServerSentEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSentEventProcessor.swift; sourceTree = "<group>"; };
 		735A4CBC241172F0004E7A41 /* NuguApiProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NuguApiProvider.swift; sourceTree = "<group>"; };
 		735A4CBD241172F1004E7A41 /* NuguApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NuguApi.swift; sourceTree = "<group>"; };
 		735A4CC424117338004E7A41 /* MultiPartParserError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiPartParserError.swift; sourceTree = "<group>"; };
@@ -1176,8 +1176,8 @@
 		7378FDD825B8191200AB9764 /* TypedNotifyable+post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TypedNotifyable+post.swift"; sourceTree = "<group>"; };
 		738224BD26D4DB5D0050D67A /* DataStreamPlayerBufferState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStreamPlayerBufferState.swift; sourceTree = "<group>"; };
 		7386DA9823CF279C002BF24C /* NuguClientDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NuguClientDelegate.swift; sourceTree = "<group>"; };
-		739078FB241A3E0B007D753F /* ServerSideEventReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSideEventReceiver.swift; sourceTree = "<group>"; };
-		739078FC241A3E0C007D753F /* ServerSideEventReceiverState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSideEventReceiverState.swift; sourceTree = "<group>"; };
+		739078FC241A3E0C007D753F /* ServerSentEventReceiverState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSentEventReceiverState.swift; sourceTree = "<group>"; };
+		73A76A592B6B942C007F4178 /* ServerSentEventReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ServerSentEventReceiver.swift; path = NuguCore/Sources/StreamData/ServerSentEventReceiver.swift; sourceTree = SOURCE_ROOT; };
 		73BF06DA26A0208700112473 /* NuguObjcUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NuguObjcUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73BF06DC26A0208700112473 /* NuguObjcUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NuguObjcUtils.h; sourceTree = "<group>"; };
 		73BF06DD26A0208700112473 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2770,7 +2770,7 @@
 				735A4CBA241172F0004E7A41 /* EventResponseProcessor.swift */,
 				735A4CBD241172F1004E7A41 /* NuguApi.swift */,
 				735A4CBC241172F0004E7A41 /* NuguApiProvider.swift */,
-				735A4CBB241172F0004E7A41 /* ServerSideEventProcessor.swift */,
+				735A4CBB241172F0004E7A41 /* ServerSentEventProcessor.swift */,
 			);
 			name = Api;
 			path = ../Api;
@@ -2792,8 +2792,7 @@
 				7373892924A46D420018DDD2 /* StreamDataRoutable.swift */,
 				7373892824A46D420018DDD2 /* StreamDataState.swift */,
 				7373892B24A46D420018DDD2 /* UpstreamDataSendable.swift */,
-				739078FB241A3E0B007D753F /* ServerSideEventReceiver.swift */,
-				739078FC241A3E0C007D753F /* ServerSideEventReceiverState.swift */,
+				739078FC241A3E0C007D753F /* ServerSentEventReceiverState.swift */,
 				7EDCF2A62384FE88006F96B6 /* StreamDataRouter.swift */,
 				735A4CDF241173F4004E7A41 /* EventSender.swift */,
 				735A4CE0241173F4004E7A41 /* EventSenderError.swift */,
@@ -2813,6 +2812,7 @@
 		7373893024A46D4D0018DDD2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				73A76A592B6B942C007F4178 /* ServerSentEventReceiver.swift */,
 				7373893124A46D4D0018DDD2 /* Upstream.swift */,
 				7373893224A46D4D0018DDD2 /* Downstream.swift */,
 			);
@@ -4085,7 +4085,7 @@
 				75082BC6243AC85E0027D76D /* FileManager+Convenience.swift in Sources */,
 				7373895724A473A60018DDD2 /* FocusChannelPriority.swift in Sources */,
 				7373894424A46E5F0018DDD2 /* ContextType.swift in Sources */,
-				739078FE241A3E0C007D753F /* ServerSideEventReceiverState.swift in Sources */,
+				739078FE241A3E0C007D753F /* ServerSentEventReceiverState.swift in Sources */,
 				7315301923E11EDF00F843C3 /* MediaPlayableError.swift in Sources */,
 				7373892124A46D120018DDD2 /* MediaPlayerDelegate.swift in Sources */,
 				7373895824A473A60018DDD2 /* FocusChannelDelegate.swift in Sources */,
@@ -4103,6 +4103,7 @@
 				1FFFF3C12375707100C9A177 /* Policy.swift in Sources */,
 				1FFFF3C82375707100C9A177 /* FocusConst.swift in Sources */,
 				7373895924A473A60018DDD2 /* FocusManageable.swift in Sources */,
+				73A76A5A2B6B942C007F4178 /* ServerSentEventReceiver.swift in Sources */,
 				7373892C24A46D430018DDD2 /* StreamDataState.swift in Sources */,
 				7373894224A46E5F0018DDD2 /* ContextInfo.swift in Sources */,
 				73454FC32387BDF00073AF48 /* NuguServerInfo.swift in Sources */,
@@ -4141,8 +4142,7 @@
 				7373894A24A46E720018DDD2 /* BlockingPolicy.swift in Sources */,
 				1FFFF3C72375707100C9A177 /* FocusManager.swift in Sources */,
 				7373893324A46D4D0018DDD2 /* Upstream.swift in Sources */,
-				739078FD241A3E0C007D753F /* ServerSideEventReceiver.swift in Sources */,
-				735A4CBF241172F1004E7A41 /* ServerSideEventProcessor.swift in Sources */,
+				735A4CBF241172F1004E7A41 /* ServerSentEventProcessor.swift in Sources */,
 				7EDCF2A72384FE88006F96B6 /* StreamDataRouter.swift in Sources */,
 				735A4CE1241173F4004E7A41 /* EventSender.swift in Sources */,
 				7373894B24A46E720018DDD2 /* DirectiveHandleInfo.swift in Sources */,


### PR DESCRIPTION
## Crash Report
<img width="984" alt="image" src="https://github.com/nugu-developers/nugu-ios/assets/28081240/3a6e9984-8f36-4019-b854-d513d086fe5b">

## Description
- `ServerSentEvent`를 `ServerSideEvent`로 오기한 부분 바로잡았습니다 (https://github.com/nugu-developers/nugu-ios/pull/1126/commits/e51f1f70bc9d434ca426f30b338b2064094bbd21)
- Crash 관련 수정은 https://github.com/nugu-developers/nugu-ios/pull/1126/commits/de08bf93874e2bf476f962a52ca58aa21c7bd214 입니다
