### PR TITLE
AudioPlayer Event 필터링 조건 수정

### DIFF
--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgent.swift
@@ -862,14 +862,9 @@ private extension AudioPlayerAgent {
     
     func playlistEvent(typeInfo: PlaylistEvent.TypeInfo) -> Single<Eventable> {
         return Single.create { [weak self] (observer) -> Disposable in
-            guard let self = self, let player = self.latestPlayer else {
-                observer(.failure(NuguAgentError.invalidState))
-                return Disposables.create()
-            }
-            
             let playlistEvent = PlaylistEvent(
                 typeInfo: typeInfo,
-                playServiceId: player.payload.playServiceId
+                playServiceId: self?.latestPlayer?.payload.playServiceId
             )
             observer(.success(playlistEvent))
             return Disposables.create()

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgentProtocol.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/AudioPlayerAgentProtocol.swift
@@ -45,6 +45,9 @@ public protocol AudioPlayerAgentProtocol: CapabilityAgentable, TypedNotifyable {
     /// This function retrieves the volume of the current `MediaPlayable` handled by the `AudioPlayerAgent`.
     var volume: Float { get set }
     
+    /// Ignore latestPlayerInfo when receive Directive
+    var ignoreLatestPlayer: Bool { get set }
+    
     /// Begins playback of the current item.
     func play()
     

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Display/AudioPlayerDisplayManager.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Display/AudioPlayerDisplayManager.swift
@@ -161,7 +161,6 @@ extension AudioPlayerDisplayManager {
     }
     
     func updateMetadata(payload: AudioPlayerUpdateMetadataPayload, playServiceId: String, header: Downstream.Header) {
-//        guard currentItem?.mediaPayload.playServiceId == playServiceId else { return }
         delegate?.audioPlayerDisplayShouldUpdateMetadata(payload: payload, header: header)
     }
     

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Display/AudioPlayerDisplayManager.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Display/AudioPlayerDisplayManager.swift
@@ -161,7 +161,7 @@ extension AudioPlayerDisplayManager {
     }
     
     func updateMetadata(payload: AudioPlayerUpdateMetadataPayload, playServiceId: String, header: Downstream.Header) {
-        guard currentItem?.mediaPayload.playServiceId == playServiceId else { return }
+//        guard currentItem?.mediaPayload.playServiceId == playServiceId else { return }
         delegate?.audioPlayerDisplayShouldUpdateMetadata(payload: payload, header: header)
     }
     

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Event/AudioPlayerAgent+PlaylistEvent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Event/AudioPlayerAgent+PlaylistEvent.swift
@@ -24,7 +24,7 @@ import Foundation
 extension AudioPlayerAgent {
     struct PlaylistEvent {
         let typeInfo: TypeInfo
-        let playServiceId: String
+        let playServiceId: String?
         
         enum TypeInfo {
             case playlistItemSelected(token: String, postback: [String: AnyHashable])

--- a/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Event/AudioPlayerAgent+PlaylistEvent.swift
+++ b/NuguAgents/Sources/CapabilityAgents/AudioPlayer/Event/AudioPlayerAgent+PlaylistEvent.swift
@@ -48,6 +48,10 @@ extension AudioPlayerAgent.PlaylistEvent: Eventable {
         case .playlistFavoriteSelected(token: let playlistItemToken, postback: let postback):
             eventPayload["token"] = playlistItemToken
             eventPayload["postback"] = postback
+            
+            if playServiceId == nil {
+                eventPayload["playServiceId"] = postback["playServiceId"]
+            }
         case .playlistItemSelected(token: let playlistItemToken, postback: let postback):
             eventPayload["token"] = playlistItemToken
             eventPayload["postback"] = postback


### PR DESCRIPTION
## Summary
- Audio가 재생중일때에만 관련 이벤트를 수신받을 수 있었으나, 그러지 않는 경우들이 생기며 해당 필터링 제거