### PR TITLE
개인 식별 api에 사용에 따른 PrivacyInfo 추가

### DIFF
--- a/NuguAgents.podspec
+++ b/NuguAgents.podspec
@@ -10,6 +10,7 @@ Default Agent Implementations for Nugu service
   s.homepage = 'https://github.com/nugu-developers/nugu-ios'
   s.author = { 'SK Telecom Co., Ltd.' => 'nugu_dev_sdk@sk.com' }
   s.source = { :git => 'https://github.com/nugu-developers/nugu-ios.git', :tag => s.version.to_s }
+  s.resource_bundles = {"NuguUtils" => ["NuguUtils/PrivacyInfo.xcprivacy"]}
   s.documentation_url = 'https://developers.nugu.co.kr'
 
   s.ios.deployment_target = '12.0'

--- a/NuguAgents/PrivacyInfo.xcprivacy
+++ b/NuguAgents/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+     <key>NSPrivacyTracking</key>
+     <false/>
+     <key>NSPrivacyCollectedDataTypes</key>
+     <array/>
+     <key>NSPrivacyTrackingDomains</key>
+     <array/>
+     <key>NSPrivacyAccessedAPITypes</key>
+     <array/>
+ </dict>
+ </plist>

--- a/NuguAgents/PrivacyInfo.xcprivacy
+++ b/NuguAgents/PrivacyInfo.xcprivacy
@@ -1,14 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>NSPrivacyTracking</key>
-     <false/>
-     <key>NSPrivacyCollectedDataTypes</key>
-     <array/>
-     <key>NSPrivacyTrackingDomains</key>
-     <array/>
-     <key>NSPrivacyAccessedAPITypes</key>
-     <array/>
- </dict>
- </plist>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string></string>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NuguClientKit.podspec
+++ b/NuguClientKit.podspec
@@ -10,6 +10,7 @@ Default Instances for Nugu service
   s.homepage = 'https://github.com/nugu-developers/nugu-ios'
   s.author = { 'SK Telecom Co., Ltd.' => 'nugu_dev_sdk@sk.com' }
   s.source = { :git => 'https://github.com/nugu-developers/nugu-ios.git', :tag => s.version.to_s }
+  s.resource_bundles = {"NuguUtils" => ["NuguUtils/PrivacyInfo.xcprivacy"]}
   s.documentation_url = 'https://developers.nugu.co.kr'
 
   s.ios.deployment_target = '12.0'

--- a/NuguClientKit/PrivacyInfo.xcprivacy
+++ b/NuguClientKit/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+     <key>NSPrivacyTracking</key>
+     <false/>
+     <key>NSPrivacyCollectedDataTypes</key>
+     <array/>
+     <key>NSPrivacyTrackingDomains</key>
+     <array/>
+     <key>NSPrivacyAccessedAPITypes</key>
+     <array/>
+ </dict>
+ </plist>

--- a/NuguClientKit/PrivacyInfo.xcprivacy
+++ b/NuguClientKit/PrivacyInfo.xcprivacy
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>NSPrivacyTracking</key>
-     <false/>
-     <key>NSPrivacyCollectedDataTypes</key>
-     <array/>
-     <key>NSPrivacyTrackingDomains</key>
-     <array/>
-     <key>NSPrivacyAccessedAPITypes</key>
-     <array/>
- </dict>
- </plist>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NuguCore.podspec
+++ b/NuguCore.podspec
@@ -10,6 +10,7 @@ Nugu framework for AI Service
   s.homepage = 'https://github.com/nugu-developers/nugu-ios'
   s.author = { 'SK Telecom Co., Ltd.' => 'nugu_dev_sdk@sk.com' }
   s.source = { :git => 'https://github.com/nugu-developers/nugu-ios.git', :tag => s.version }
+  s.resource_bundles = {"NuguUtils" => ["NuguUtils/PrivacyInfo.xcprivacy"]}
   s.documentation_url = 'https://developers.nugu.co.kr'
 
   s.ios.deployment_target = '12.0'

--- a/NuguCore/PrivacyInfo.xcprivacy
+++ b/NuguCore/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+     <key>NSPrivacyTracking</key>
+     <false/>
+     <key>NSPrivacyCollectedDataTypes</key>
+     <array/>
+     <key>NSPrivacyTrackingDomains</key>
+     <array/>
+     <key>NSPrivacyAccessedAPITypes</key>
+     <array/>
+ </dict>
+ </plist>

--- a/NuguCore/PrivacyInfo.xcprivacy
+++ b/NuguCore/PrivacyInfo.xcprivacy
@@ -1,14 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>NSPrivacyTracking</key>
-     <false/>
-     <key>NSPrivacyCollectedDataTypes</key>
-     <array/>
-     <key>NSPrivacyTrackingDomains</key>
-     <array/>
-     <key>NSPrivacyAccessedAPITypes</key>
-     <array/>
- </dict>
- </plist>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NuguUtils.podspec
+++ b/NuguUtils.podspec
@@ -10,6 +10,7 @@ Framework for login using OAuth 2.0
   s.homepage = 'https://github.com/nugu-developers/nugu-ios'
   s.author = { 'SK Telecom Co., Ltd.' => 'nugu_dev_sdk@sk.com' }
   s.source = { :git => 'https://github.com/nugu-developers/nugu-ios.git', :tag => s.version.to_s }
+  s.resource_bundles = {"NuguUtils" => ["NuguUtils/PrivacyInfo.xcprivacy"]}
   s.documentation_url = 'https://developers.nugu.co.kr'
 
   s.ios.deployment_target = '12.0'

--- a/NuguUtils/PrivacyInfo.xcprivacy
+++ b/NuguUtils/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+     <key>NSPrivacyTracking</key>
+     <false/>
+     <key>NSPrivacyCollectedDataTypes</key>
+     <array/>
+     <key>NSPrivacyTrackingDomains</key>
+     <array/>
+     <key>NSPrivacyAccessedAPITypes</key>
+     <array/>
+ </dict>
+ </plist>

--- a/NuguUtils/PrivacyInfo.xcprivacy
+++ b/NuguUtils/PrivacyInfo.xcprivacy
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-     <key>NSPrivacyTracking</key>
-     <false/>
-     <key>NSPrivacyCollectedDataTypes</key>
-     <array/>
-     <key>NSPrivacyTrackingDomains</key>
-     <array/>
-     <key>NSPrivacyAccessedAPITypes</key>
-     <array/>
- </dict>
- </plist>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/nugu-ios.xcodeproj/project.pbxproj
+++ b/nugu-ios.xcodeproj/project.pbxproj
@@ -529,6 +529,10 @@
 		E649868A28337649001AD733 /* ControlCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E649868928337649001AD733 /* ControlCenterManager.swift */; };
 		E6BE047C2A0BA1A400AE29E3 /* Image+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BE047B2A0BA1A400AE29E3 /* Image+Event.swift */; };
 		E6BE047E2A0BA1BD00AE29E3 /* ImageAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BE047D2A0BA1BD00AE29E3 /* ImageAgent.swift */; };
+		E6D10A982B9FD2FE0004DE40 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E6D10A972B9FD2FE0004DE40 /* PrivacyInfo.xcprivacy */; };
+		E6D10A9A2B9FD9C20004DE40 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E6D10A992B9FD9C20004DE40 /* PrivacyInfo.xcprivacy */; };
+		E6D10A9C2B9FD9E80004DE40 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E6D10A9B2B9FD9E80004DE40 /* PrivacyInfo.xcprivacy */; };
+		E6D10A9E2B9FDBB10004DE40 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E6D10A9D2B9FDBB10004DE40 /* PrivacyInfo.xcprivacy */; };
 		E6F3DCBD2B4CB9D800298A20 /* ASRAgentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F3DCBC2B4CB9D800298A20 /* ASRAgentDelegate.swift */; };
 		E6FBA02B2A1379C500AF8B05 /* MessengerAgentProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FBA02A2A1379C400AF8B05 /* MessengerAgentProtocol.swift */; };
 		E6FBA02D2A137A9700AF8B05 /* ImageAgentProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FBA02C2A137A9700AF8B05 /* ImageAgentProtocol.swift */; };
@@ -1332,6 +1336,10 @@
 		E649868928337649001AD733 /* ControlCenterManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlCenterManager.swift; sourceTree = "<group>"; };
 		E6BE047B2A0BA1A400AE29E3 /* Image+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Event.swift"; sourceTree = "<group>"; };
 		E6BE047D2A0BA1BD00AE29E3 /* ImageAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAgent.swift; sourceTree = "<group>"; };
+		E6D10A972B9FD2FE0004DE40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E6D10A992B9FD9C20004DE40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E6D10A9B2B9FD9E80004DE40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E6D10A9D2B9FDBB10004DE40 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E6F3DCBC2B4CB9D800298A20 /* ASRAgentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASRAgentDelegate.swift; sourceTree = "<group>"; };
 		E6FBA02A2A1379C400AF8B05 /* MessengerAgentProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerAgentProtocol.swift; sourceTree = "<group>"; };
 		E6FBA02C2A137A9700AF8B05 /* ImageAgentProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAgentProtocol.swift; sourceTree = "<group>"; };
@@ -1857,6 +1865,7 @@
 				1FFFF30B2375707000C9A177 /* Sources */,
 				1FFFEFFF23753F1800C9A177 /* NuguCore.h */,
 				1FFFF00023753F1800C9A177 /* Info.plist */,
+				E6D10A9D2B9FDBB10004DE40 /* PrivacyInfo.xcprivacy */,
 			);
 			path = NuguCore;
 			sourceTree = "<group>";
@@ -1867,6 +1876,7 @@
 				1FFFF3D72375735E00C9A177 /* Sources */,
 				1FFFF00C23753F3100C9A177 /* NuguClientKit.h */,
 				1FFFF00D23753F3100C9A177 /* Info.plist */,
+				E6D10A992B9FD9C20004DE40 /* PrivacyInfo.xcprivacy */,
 			);
 			path = NuguClientKit;
 			sourceTree = "<group>";
@@ -2561,6 +2571,7 @@
 				7314DF67255E3EDB004882BB /* Sources */,
 				7314DF49255E3EA2004882BB /* NuguUtils.h */,
 				7314DF4A255E3EA2004882BB /* Info.plist */,
+				E6D10A9B2B9FD9E80004DE40 /* PrivacyInfo.xcprivacy */,
 			);
 			path = NuguUtils;
 			sourceTree = "<group>";
@@ -2598,6 +2609,7 @@
 				73152FA623E0411200F843C3 /* Sources */,
 				73152F9C23E0405900F843C3 /* NuguAgents.h */,
 				73152F9D23E0405900F843C3 /* Info.plist */,
+				E6D10A972B9FD2FE0004DE40 /* PrivacyInfo.xcprivacy */,
 			);
 			path = NuguAgents;
 			sourceTree = "<group>";
@@ -3690,6 +3702,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6D10A9E2B9FDBB10004DE40 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3697,6 +3710,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6D10A9A2B9FD9C20004DE40 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3772,6 +3786,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6D10A9C2B9FD9E80004DE40 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3779,6 +3794,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6D10A982B9FD2FE0004DE40 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Description
작업 항목
개인 식별 api를 사용하고 있는지 확인하고 있다면 PrivacyInfo.xcprivacy 를 추가하고 사용 항목과 이유를 명시
 
반영 시기
2024년 3월 13일부터 누락된 경우 이메일로 경고를 보내고, 5월 1일부터는 리젝.
3월 4주차에 반영해서 누락된게 있는지 확인 후 5월전에는 모두 반영될 수 있도록 해야 함
공지 : https://developer.apple.com/news/?id=3d8a9yyh
 
애플 가이드
[Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)
장치 또는 사용자를 식별하기 위해 장치 신호에 액세스하는 데 오용될 가능성이 있습니다(지문 채취라고도 함). 사용자가 앱에 추적 권한을 부여했는지 여부에 관계없이 지문 채취는 허용되지 않습니다. 앱이나 타사 SDK(Apple에서 제공하지 않는 SDK)에서 이 API를 사용하는 경우 앱이나 타사 SDK의 PrivacyInfo.xcprivacy 파일에서 API 사용 이유와 사용법을 명시하세요.
2023년 가을부터 개인 정보 매니페스트 파일에 이유를 설명하지 않고 필수 이유 API를 사용하는 앱을 App Store Connect에 업로드하면 Apple로부터 이메일을 받게 됩니다. 2024년 봄부터 개인 정보 매니페스트 파일에 필수 이유 API 사용을 설명하지 않는 앱은 App Store Connect에서 허용되지 않습니다.