### PR TITLE
AudioSession이 Deactive되었을때 AudioSession을 다시 업데이트 하는 현상 제거

### DIFF
--- a/NuguClientKit/Sources/Audio/AudioSessionManager.swift
+++ b/NuguClientKit/Sources/Audio/AudioSessionManager.swift
@@ -153,7 +153,6 @@ public extension AudioSessionManager {
         log.debug("")
         // Defer statement for recovering audioSession and MicInputProvider
         defer {
-            updateAudioSession()
             delegate?.audioSessionDidDeactivate()
         }
         do {


### PR DESCRIPTION
## Summary
- AudioSession이 Deactive되었을때 AudioSession을 다시 업데이트 하는 현상 제거
     - https://github.com/nugu-developers/nugu-ios/pull/961 에서 변경된 코드이나 여기서 일부는 코드가 다른곳으로 옮겨짐
     - 그러나 deactive시 updateAudioSession()하는 코드를 제거했으나 revert되면서 다시 추가됨(https://github.com/nugu-developers/nugu-ios/pull/965)
     