### PR TITLE
BackgroundFocusHolder 내 targetEvent 에 TTS.TextInput 제거

### DIFF
--- a/NuguClientKit/Sources/Business/BackgroundFocusHolder.swift
+++ b/NuguClientKit/Sources/Business/BackgroundFocusHolder.swift
@@ -29,7 +29,6 @@ class BackgroundFocusHolder {
     private let queue = DispatchQueue(label: "com.sktelecom.romaine.dummy_focus_requester")
     // Prevent releasing focus while these event are being processed.
     private let focusTargets = [
-        "Text.TextInput",
         "TTS.SpeechFinished",
         "AudioPlayer.PlaybackFinished",
         "MediaPlayer.PlaySuspended"


### PR DESCRIPTION
### Description
- BackgroundFocusHolder 내 targetEvent 에 TTS.TextInput 제거
- #556 때 focusTarget에 `Text.Input` Event가 포함되었는데, Text Interface에서 focus를 가져가지 않아도 된다라고 판단해서 삭제.