### PR TITLE
ServerInitiatedDirectiveRecevierStateDidChange가 정확하게 내려오지 않던 문제 수정

### DIFF
--- a/NuguCore/Sources/StreamData/StreamDataRouter.swift
+++ b/NuguCore/Sources/StreamData/StreamDataRouter.swift
@@ -66,6 +66,10 @@ public extension StreamDataRouter {
                     
                     self?.post(state)
                 }
+            }, onError: { [weak self] error in
+                self?.post(ServerSentEventReceiverState.disconnected(error: error))
+            }, onDisposed: { [weak self] in
+                self?.post(ServerSentEventReceiverState.unconnected)
             })
         serverInitiatedDirectiveStateDisposable?.disposed(by: disposeBag)
         
@@ -234,6 +238,7 @@ public extension StreamDataRouter {
 }
 
 // MARK: - private
+
 extension StreamDataRouter {
     /**
      Send directive or attachment to `DirectiveSequencer` and Call closure


### PR DESCRIPTION
### Description
- ServerInitiatedDirectiveRecevierStateDidChange가 정확하게 내려오지 않던 문제 수정
- `startReceiveServerInitiatedDirective`, `stopReceiveServerInitiatedDirective` 를 호출할 때 `unconnected` 혹은 `disconnected` 보다 `serverInitiatedDirectiveStateDisposable` 이 우선적으로 dispose 되고 있어서 state를 정상적으로 수신할 수 없고, NuguClient의 delegate 메서드에서 `unconnected`, `disconnected`를 수신할 수 없었음.