### PR TITLE
AudioSession Category 변경시 audioSessionUpdate하는 로직 수정

### DIFF
--- a/NuguClientKit/Sources/Audio/AudioSessionManager.swift
+++ b/NuguClientKit/Sources/Audio/AudioSessionManager.swift
@@ -222,7 +222,7 @@ private extension AudioSessionManager {
                 self?.delegate?.audioSessionRouteChanged(reason: .categoryChange)
                 
                 if self?.isCarplayConnected() == true {
-                    self?.updateAudioSession(requestingFocus: true)
+                    self?.updateAudioSession()
                 }
             default: break
             }

--- a/NuguClientKit/Sources/Client/NuguClient.swift
+++ b/NuguClientKit/Sources/Client/NuguClient.swift
@@ -770,12 +770,10 @@ extension NuguClient: AudioSessionManagerDelegate {
             if previousRoute?.outputs.first?.portType == .carAudio {
                 speechRecognizerAggregator.startListeningWithTrigger()
             }
-        case .newDeviceAvailable:
+        case .newDeviceAvailable, .categoryChange:
             if audioSessionManager?.isCarplayConnected() == true {
                 speechRecognizerAggregator.stopListening()
             }
-        case .categoryChange:
-            break
         }
     }
     


### PR DESCRIPTION
## Summary
- AudioSession Category 변경시 audioSessionUpdate하는 로직 수정
     -  [AudioCategory의 상태가 categoryChanged일경우 NewDeviceAvailable과 동일하게 동작하도록 적용](https://github.com/nugu-developers/nugu-ios/commit/54f9e0baadecfed01666a568eb3c036aa93aed2e)
           - 기존 categoryChanged의 경우 break로 아무동작도 하지않아 audioSession을 업데이트해주지 않는 문제 발생
           - 동일하게 처리할수 있도록 적용
     - [categoryChange, routeConfigurationChanged일때 updateAudioSesion에서 focus요청하지 않도록 적용](https://github.com/nugu-developers/nugu-ios/commit/b0247f330573ceb8c32e1a877c083368bfc81b7f)
           - 위 처리에서 playback, playAndRecord관련 처리를 하고 있으므로 해당 커밋에서 requestFocus삭제