### PR TITLE
AudioSessionManager에서 중복으로 updateAudioSession() 수행하던 현상 수정

### DIFF
--- a/NuguClientKit/Sources/Audio/AudioSessionManager.swift
+++ b/NuguClientKit/Sources/Audio/AudioSessionManager.swift
@@ -70,7 +70,7 @@ final public class AudioSessionManager: AudioSessionManageable {
 
 public extension AudioSessionManager {
     func isCarplayConnected() -> Bool {
-        AVAudioSession.sharedInstance().availableInputs?.contains(where: { $0.portType == .carAudio }) ?? false
+        AVAudioSession.sharedInstance().currentRoute.outputs.contains(where: { $0.portType == .carAudio })
     }
     
     func requestRecordPermission(_ response: @escaping (Bool) -> Void) {

--- a/NuguClientKit/Sources/Audio/AudioSessionManager.swift
+++ b/NuguClientKit/Sources/Audio/AudioSessionManager.swift
@@ -220,10 +220,6 @@ private extension AudioSessionManager {
                 }
             case .categoryChange, .routeConfigurationChange:
                 self?.delegate?.audioSessionRouteChanged(reason: .categoryChange)
-                
-                if self?.isCarplayConnected() == true {
-                    self?.updateAudioSession()
-                }
             default: break
             }
         })


### PR DESCRIPTION
## Summary
- AudioSessionManager에서 중복으로 updateAudioSession() 수행하던 현상 수정
   - Delegate를 통해 이벤트를 전달 하고, 전달 받는 쪽에서 이미 updateAudioSession()을 수행하고 있기 때문에, 중복하여 호출하는 부분 제거